### PR TITLE
test: add test for external book search

### DIFF
--- a/prisma/migrations/20240123185359_published_date_optional/migration.sql
+++ b/prisma/migrations/20240123185359_published_date_optional/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Book" ALTER COLUMN "publishedDate" DROP NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,12 +11,12 @@ datasource db {
 }
 
 model Book {
-  id            Int      @id @default(autoincrement())
-  isbn          String   @unique
+  id            Int       @id @default(autoincrement())
+  isbn          String    @unique
   author        String
   genre         String
   imageUrl      String?
-  publishedDate DateTime
+  publishedDate DateTime?
   publisher     String
   title         String
 }

--- a/src/app/add/page.tsx
+++ b/src/app/add/page.tsx
@@ -65,7 +65,7 @@ export default function AddBookPage() {
     values: {
       author: lookupBook?.author || '',
       genre: lookupBook?.genre || '',
-      imageUrl: lookupBook?.imageUrl,
+      imageUrl: lookupBook?.imageUrl || '',
       isbn: lookupBook?.isbn || '',
       publishedDate: lookupBook?.publishedDate?.toLocaleDateString?.() || '',
       publisher: lookupBook?.publisher || '',

--- a/src/lib/search/external/useExternalBookSearch.test.ts
+++ b/src/lib/search/external/useExternalBookSearch.test.ts
@@ -1,5 +1,137 @@
+import useExternalBookSearch, {
+  GoogleSearchResponse,
+  UseExternalBookSearchResult,
+} from '@/lib/search/external/useExternalBookSearch';
+import { Book } from '@/types/Book';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+
 describe('useExternalBookSearch', () => {
-  it('should work', () => {
-    expect(true).toEqual(true);
+  const GOOGLE_BOOK_FOUND: GoogleSearchResponse = {
+    items: [
+      {
+        volumeInfo: {
+          authors: ['Cressida Cowell'],
+          categories: ['Juvenile Fiction'],
+          imageLinks: {
+            thumbnail:
+              'http://books.google.com/books/content?id=28_qngEACAAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api',
+          },
+          industryIdentifiers: [
+            {
+              identifier: '0316085278',
+              type: 'ISBN_10',
+            },
+            {
+              identifier: '9780316085274',
+              type: 'ISBN_13',
+            },
+          ],
+          publishedDate: new Date('2010-02-01'),
+          publisher: 'Little Brown & Company',
+          title: 'How to Train Your Dragon',
+        },
+      },
+    ],
+    totalItems: 1,
+  };
+
+  const GOOGLE_BOOK_FOUND_WITHOUT_DETAIL: GoogleSearchResponse = {
+    items: [
+      {
+        volumeInfo: {
+          industryIdentifiers: [],
+          publisher: 'Little Brown & Company',
+          title: 'How to Train Your Dragon',
+        },
+      },
+    ],
+    totalItems: 1,
+  };
+
+  const GOOGLE_BOOK_NOT_FOUND: GoogleSearchResponse = {
+    items: [],
+    totalItems: 0,
+  };
+
+  let search: UseExternalBookSearchResult;
+  beforeEach(() => {
+    search = useExternalBookSearch();
+  });
+
+  describe('search by ISBN', () => {
+    const isbn = '123';
+
+    describe('when the book exists', () => {
+      const server = setupServer(
+        rest.get('https://www.googleapis.com/*', (_, res, ctx) => {
+          return res(ctx.json(GOOGLE_BOOK_FOUND));
+        }),
+      );
+      const book: Book = {
+        author: 'Cressida Cowell',
+        genre: 'Juvenile Fiction',
+        imageUrl:
+          'https://books.google.com/books/content?id=28_qngEACAAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api',
+        isbn: '9780316085274',
+        publishedDate: new Date('2010-02-01'),
+        publisher: 'Little Brown & Company',
+        title: 'How to Train Your Dragon',
+      };
+
+      beforeAll(() => server.listen());
+      afterEach(() => server.resetHandlers());
+      afterAll(() => server.close());
+
+      it('should return the book details', async () => {
+        const result = await search({ isbn });
+        expect(result).not.toBeNull();
+        expect(result).toEqual(book);
+      });
+    });
+
+    describe('when the book exists without detail', () => {
+      const server = setupServer(
+        rest.get('https://www.googleapis.com/*', (_, res, ctx) => {
+          return res(ctx.json(GOOGLE_BOOK_FOUND_WITHOUT_DETAIL));
+        }),
+      );
+      const book: Book = {
+        author: '',
+        genre: '',
+        imageUrl: null,
+        isbn: '',
+        publishedDate: null,
+        publisher: 'Little Brown & Company',
+        title: 'How to Train Your Dragon',
+      };
+
+      beforeAll(() => server.listen());
+      afterEach(() => server.resetHandlers());
+      afterAll(() => server.close());
+
+      it('should return the book details', async () => {
+        const result = await search({ isbn });
+        expect(result).not.toBeNull();
+        expect(result).toEqual(book);
+      });
+    });
+
+    describe('when the book does NOT exist', () => {
+      const server = setupServer(
+        rest.get('https://www.googleapis.com/*', (_, res, ctx) => {
+          return res(ctx.json(GOOGLE_BOOK_NOT_FOUND));
+        }),
+      );
+
+      beforeAll(() => server.listen());
+      afterEach(() => server.resetHandlers());
+      afterAll(() => server.close());
+
+      it('should return null', async () => {
+        const result = await search({ isbn });
+        expect(result).toBeNull();
+      });
+    });
   });
 });

--- a/src/types/Book.tsx
+++ b/src/types/Book.tsx
@@ -1,9 +1,9 @@
 export interface Book {
   author: string;
   genre: string;
-  imageUrl?: string | null;
+  imageUrl: string | null;
   isbn: string;
-  publishedDate: Date;
+  publishedDate: Date | null;
   publisher: string;
   title: string;
   // TODO add subtitle and description


### PR DESCRIPTION
- Add tests for useExternalBookSearch. This raised some potential changes that were made, including:
- Change the Book type to make imageUrl and publishedDate nullable. Apply migration to the DB schema.
- More clearly state the types for useExternalBookSearch