### PR TITLE
chore: cleanup css (tailwind + components)

### DIFF
--- a/components.json
+++ b/components.json
@@ -7,7 +7,7 @@
     "config": "tailwind.config.ts",
     "css": "src/app/globals.css",
     "baseColor": "slate",
-    "cssVariables": true,
+    "cssVariables": false,
     "prefix": ""
   },
   "aliases": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-hook-form": "7.48.2",
-    "tailwind-merge": "2.2.0",
+    "tailwind-merge": "2.2.1",
     "tailwindcss-animate": "1.0.7"
   },
   "devDependencies": {

--- a/src/app/add/page.tsx
+++ b/src/app/add/page.tsx
@@ -7,7 +7,6 @@ import {
   UseFormRegister,
   useForm,
 } from 'react-hook-form';
-import clsx from 'clsx';
 import Image from 'next/image';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -38,12 +37,10 @@ function AddBookFormInput({
 
   return (
     <div className="flex flex-col flex-1">
-      <label className="text-sm text-customPalette-500 capitalize">
-        {fieldNameToDisplay}
-      </label>
+      <label className="text-sm capitalize">{fieldNameToDisplay}</label>
       <Input
-        className={clsx(errors[fieldName] && 'border-red-500')}
         type="text"
+        variant={errors[fieldName] ? 'error' : 'default'}
         {...register(fieldName, { required: true })}
       />
     </div>
@@ -93,7 +90,7 @@ export default function AddBookPage() {
 
   return (
     <div>
-      <h1 className="text-2xl text-customPalette-500 my-4">Add a Book</h1>
+      <h1 className="text-2xl my-4">Add a Book</h1>
       <hr className="mt-4 mb-8 border-customPalette-300" />
 
       <form
@@ -123,7 +120,7 @@ export default function AddBookPage() {
                 height={192}
               />
             ) : (
-              <div className="border rounded-sm border-customPalette-200 w-[128px] h-[192px] flex justify-center items-center text-customPalette-500">
+              <div className="border rounded-sm border-customPalette-200 w-[128px] h-[192px] flex justify-center items-center">
                 No Image
               </div>
             )}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,46 +2,6 @@
 @tailwind components;
 @tailwind utilities;
 
-@layer base {
-  :root {
-    --background: 0 0% 100%;
-    --foreground: 222.2 84% 4.9%;
-
-    --card: 0 0% 100%;
-    --card-foreground: 222.2 84% 4.9%;
-
-    --popover: 0 0% 100%;
-    --popover-foreground: 222.2 84% 4.9%;
-
-    --primary: 222.2 47.4% 11.2%;
-    --primary-foreground: 210 40% 98%;
-
-    --secondary: 210 40% 96.1%;
-    --secondary-foreground: 222.2 47.4% 11.2%;
-
-    --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 46.9%;
-
-    --accent: 210 40% 96.1%;
-    --accent-foreground: 222.2 47.4% 11.2%;
-
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 210 40% 98%;
-
-    --border: 214.3 31.8% 91.4%;
-    --input: 214.3 31.8% 91.4%;
-    --ring: 222.2 84% 4.9%;
-
-    --radius: 0.5rem;
-  }
-}
-
-@layer base {
-  * {
-    @apply border-border;
-  }
-
-  body {
-    @apply bg-background text-foreground;
-  }
+body {
+  @apply bg-customPalette-100 text-customPalette-500;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,7 +15,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className="bg-customPalette-100 min-h-screen min-w-screen flex flex-col">
+      <body className="min-h-screen min-w-screen flex flex-col">
         <Nav />
         <div className="flex flex-1">
           <SideNav />

--- a/src/app/list/page.tsx
+++ b/src/app/list/page.tsx
@@ -63,7 +63,7 @@ export default function ListPage() {
 
   return (
     <>
-      <h1 className="text-2xl text-customPalette-500 my-4">Books</h1>
+      <h1 className="text-2xl my-4">Books</h1>
       <hr className="mt-4 mb-8 border-customPalette-300" />
 
       <Books

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -25,7 +25,7 @@ export default function SearchPage() {
 
   return (
     <div>
-      <h1 className="text-2xl text-customPalette-500 my-4">Search</h1>
+      <h1 className="text-2xl my-4">Search</h1>
       <hr className="mt-4 mb-8 border-customPalette-300" />
 
       <SearchForm onSearch={onSearch} ref={inputElement} />

--- a/src/components/Book.tsx
+++ b/src/components/Book.tsx
@@ -31,11 +31,11 @@ export default function Book({ book }: { book: BookType }) {
       {book.imageUrl ? (
         <Image alt={book.title} src={book.imageUrl} width={128} height={192} />
       ) : (
-        <div className="border rounded-sm border-customPalette-300 w-[128px] h-[192px] flex justify-center items-center text-slate-900">
+        <div className="border rounded-sm border-customPalette-300 w-[128px] h-[192px] flex justify-center items-center">
           No Image
         </div>
       )}
-      <div className="flex flex-col justify-between text-customPalette-500">
+      <div className="flex flex-col justify-between">
         <div>
           <div className="text-xl font-bold mb-2">{book.title}</div>
         </div>

--- a/src/components/BookSkeleton.tsx
+++ b/src/components/BookSkeleton.tsx
@@ -9,7 +9,7 @@ export default function BookSkeleton() {
       <div className="">
         <Skeleton className="h-[192px] w-[128px]" />
       </div>
-      <div className="flex flex-col w-full justify-between text-customPalette-500">
+      <div className="flex flex-col w-full justify-between">
         <div>
           <Skeleton className="h-7 w-full mb-2" />
         </div>

--- a/src/components/SideNav.tsx
+++ b/src/components/SideNav.tsx
@@ -22,7 +22,7 @@ function NavElement({ path, text }: { path: string; text: string }) {
 
 export default function SideNav() {
   return (
-    <nav className="flex flex-col w-[140px] bg-customPalette-200 text-customPalette-500">
+    <nav className="flex flex-col w-[140px] bg-customPalette-200">
       <NavElement path="/search" text="Search" />
       <NavElement path="/add" text="Add" />
       <NavElement path="/list" text="List" />

--- a/src/components/stories/Book.stories.tsx
+++ b/src/components/stories/Book.stories.tsx
@@ -22,3 +22,17 @@ export const Default: Story = {
   },
 };
 Default.storyName = 'Book';
+
+export const NoImage: Story = {
+  args: {
+    book: {
+      author: 'Biff Spiffington',
+      genre: 'Fiction',
+      imageUrl: null,
+      isbn: '123',
+      publishedDate: new Date('2000-01-02'),
+      publisher: 'My Publisher',
+      title: 'My Book',
+    },
+  },
+};

--- a/src/components/stories/ui/button.stories.tsx
+++ b/src/components/stories/ui/button.stories.tsx
@@ -1,0 +1,36 @@
+import { Button } from '@/components/ui/button';
+import { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<typeof Button> = {
+  args: {
+    children: 'Click me',
+  },
+  component: Button,
+};
+
+export default meta;
+type Story = StoryObj<typeof Button>;
+
+export const Default: Story = {
+  args: { variant: 'default' },
+};
+
+export const destructive: Story = {
+  args: { variant: 'destructive' },
+};
+
+export const ghost: Story = {
+  args: { variant: 'ghost' },
+};
+
+export const link: Story = {
+  args: { variant: 'link' },
+};
+
+export const outline: Story = {
+  args: { variant: 'outline' },
+};
+
+export const secondary: Story = {
+  args: { variant: 'secondary' },
+};

--- a/src/components/stories/ui/input.stories.tsx
+++ b/src/components/stories/ui/input.stories.tsx
@@ -1,0 +1,20 @@
+import { Input } from '@/components/ui/input';
+import { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<typeof Input> = {
+  args: {
+    type: 'text',
+  },
+  component: Input,
+};
+
+export default meta;
+type Story = StoryObj<typeof Input>;
+
+export const Default: Story = {
+  args: {},
+};
+
+export const error: Story = {
+  args: { variant: 'error' },
+};

--- a/src/components/stories/ui/loading-spinner.stories.tsx
+++ b/src/components/stories/ui/loading-spinner.stories.tsx
@@ -1,0 +1,21 @@
+import { LoadingSpinner } from '@/components/ui/loading-spinner';
+import { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<typeof LoadingSpinner> = {
+  component: LoadingSpinner,
+};
+
+export default meta;
+type Story = StoryObj<typeof LoadingSpinner>;
+
+export const Default: Story = {
+  args: {},
+};
+
+export const large: Story = {
+  args: { size: 'lg' },
+};
+
+export const small: Story = {
+  args: { size: 'sm' },
+};

--- a/src/components/stories/ui/pagination.stories.tsx
+++ b/src/components/stories/ui/pagination.stories.tsx
@@ -1,0 +1,87 @@
+import { Input } from '@/components/ui/input';
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationNext,
+  PaginationPrevious,
+} from '@/components/ui/pagination';
+import { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<typeof Input> = {
+  args: {
+    type: 'text',
+  },
+  component: Input,
+};
+
+export default meta;
+type Story = StoryObj<typeof Input>;
+
+export const BothEnabled: Story = {
+  render: () => {
+    return (
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationPrevious href="#" />
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationNext href="#" />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>
+    );
+  },
+};
+
+export const PreviousDisabled: Story = {
+  render: () => {
+    return (
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationPrevious href="#" isDisabled />
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationNext href="#" />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>
+    );
+  },
+};
+
+export const NextDisabled: Story = {
+  render: () => {
+    return (
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationPrevious href="#" />
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationNext href="#" isDisabled />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>
+    );
+  },
+};
+
+export const BothDisabled: Story = {
+  render: () => {
+    return (
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationPrevious href="#" isDisabled />
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationNext href="#" isDisabled />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>
+    );
+  },
+};

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from 'lib/utils';
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50',
+  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-customPalette-500 disabled:pointer-events-none disabled:opacity-50',
   {
     defaultVariants: {
       size: 'default',
@@ -22,13 +22,13 @@ const buttonVariants = cva(
         default:
           'bg-customPalette-400 text-customPalette-100 shadow hover:bg-customPalette-400/90',
         destructive:
-          'bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90',
-        ghost: 'hover:bg-accent hover:text-accent-foreground',
-        link: 'text-primary underline-offset-4 hover:underline',
+          'bg-red-500 text-customPalette-100 shadow-sm hover:bg-red-500/90',
+        ghost: 'hover:bg-customPalette-100 hover:text-customPalette-300/80',
+        link: 'underline-offset-4 hover:underline',
         outline:
-          'border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground',
+          'border border-customPalette-300 bg-white shadow-sm hover:bg-white/50',
         secondary:
-          'bg-customPalette-100 text-customPalette-400 border border-customPalette-300 shadow-sm hover:bg-customPalette-200/20',
+          'bg-customPalette-100 border border-customPalette-300 shadow-sm hover:bg-white/50',
       },
     },
   },

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,20 +1,32 @@
 import * as React from 'react';
-
+import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from 'lib/utils';
 
+const inputVariants = cva(
+  'flex h-9 w-full rounded-md border border-customPalette-200 bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-slate-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-slate-950 disabled:cursor-not-allowed disabled:opacity-50',
+  {
+    defaultVariants: {
+      variant: 'default',
+    },
+    variants: {
+      variant: {
+        default: '',
+        error: 'border-red-500',
+      },
+    },
+  },
+);
+
 export interface InputProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {}
+  extends React.InputHTMLAttributes<HTMLInputElement>,
+    VariantProps<typeof inputVariants> {}
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className, type, ...props }, ref) => {
+  ({ className, type, variant, ...props }, ref) => {
     return (
       <input
         type={type}
-        className={cn(
-          'flex h-9 w-full rounded-md border border-input px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
-          'border-customPalette-200 bg-customPalette-100',
-          className,
-        )}
+        className={cn(inputVariants({ className, variant }))}
         ref={ref}
         {...props}
       />
@@ -23,4 +35,4 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
 );
 Input.displayName = 'Input';
 
-export { Input };
+export { Input, inputVariants };

--- a/src/components/ui/loading-spinner.tsx
+++ b/src/components/ui/loading-spinner.tsx
@@ -4,7 +4,7 @@ import { cn } from 'lib/utils';
 import { Loader2 } from 'lucide-react';
 import { VariantProps, cva } from 'class-variance-authority';
 
-const loadingVariants = cva('text-customPalette-400 animate-spin', {
+const loadingVariants = cva('animate-spin', {
   defaultVariants: {
     size: 'default',
   },

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -60,8 +60,8 @@ const PaginationLink = ({
         size,
         variant: isActive ? 'outline' : 'ghost',
       }),
-      'text-customPalette-400',
-      isDisabled && 'pointer-events-none text-customPalette-400/50',
+      isDisabled &&
+        'text-customPalette-500/50 hover:text-customPalette-500/50 cursor-not-allowed',
       className,
     )}
     {...props}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,6 @@
 import type { Config } from 'tailwindcss';
 
-const config: Config = {
+const config = {
   content: [
     './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
     './src/components/**/*.{js,ts,jsx,tsx,mdx}',
@@ -8,17 +8,6 @@ const config: Config = {
   ],
   plugins: [require('tailwindcss-animate')],
   theme: {
-    colors: ({ colors }) => ({
-      ...colors,
-      // https://coolors.co/palette/134074-13315c-0b2545-8da9c4-eef4ed
-      customPalette: {
-        100: '#EEF4ED',
-        200: '#8DA9C4',
-        300: '#134074',
-        400: '#13315C',
-        500: '#0B2545',
-      },
-    }),
     container: {
       center: true,
       padding: '2rem',
@@ -31,44 +20,14 @@ const config: Config = {
         'accordion-down': 'accordion-down 0.2s ease-out',
         'accordion-up': 'accordion-up 0.2s ease-out',
       },
-      borderRadius: {
-        lg: 'var(--radius)',
-        md: 'calc(var(--radius) - 2px)',
-        sm: 'calc(var(--radius) - 4px)',
-      },
       colors: {
-        accent: {
-          DEFAULT: 'hsl(var(--accent))',
-          foreground: 'hsl(var(--accent-foreground))',
-        },
-        background: 'hsl(var(--background))',
-        border: 'hsl(var(--border))',
-        card: {
-          DEFAULT: 'hsl(var(--card))',
-          foreground: 'hsl(var(--card-foreground))',
-        },
-        destructive: {
-          DEFAULT: 'hsl(var(--destructive))',
-          foreground: 'hsl(var(--destructive-foreground))',
-        },
-        foreground: 'hsl(var(--foreground))',
-        input: 'hsl(var(--input))',
-        muted: {
-          DEFAULT: 'hsl(var(--muted))',
-          foreground: 'hsl(var(--muted-foreground))',
-        },
-        popover: {
-          DEFAULT: 'hsl(var(--popover))',
-          foreground: 'hsl(var(--popover-foreground))',
-        },
-        primary: {
-          DEFAULT: 'hsl(var(--primary))',
-          foreground: 'hsl(var(--primary-foreground))',
-        },
-        ring: 'hsl(var(--ring))',
-        secondary: {
-          DEFAULT: 'hsl(var(--secondary))',
-          foreground: 'hsl(var(--secondary-foreground))',
+        // https://coolors.co/palette/134074-13315c-0b2545-8da9c4-eef4ed
+        customPalette: {
+          100: '#EEF4ED',
+          200: '#8DA9C4',
+          300: '#134074',
+          400: '#13315C',
+          500: '#0B2545',
         },
       },
       keyframes: {
@@ -83,5 +42,6 @@ const config: Config = {
       },
     },
   },
-};
+} satisfies Config;
+
 export default config;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1539,7 +1539,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.23.5, @babel/runtime@npm:^7.9.2":
+"@babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.9.2":
   version: 7.23.8
   resolution: "@babel/runtime@npm:7.23.8"
   dependencies:
@@ -1548,7 +1548,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.8.4":
+"@babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.23.7, @babel/runtime@npm:^7.8.4":
   version: 7.23.9
   resolution: "@babel/runtime@npm:7.23.9"
   dependencies:
@@ -6245,7 +6245,7 @@ __metadata:
     react-dom: "npm:18.2.0"
     react-hook-form: "npm:7.48.2"
     storybook: "npm:7.6.10"
-    tailwind-merge: "npm:2.2.0"
+    tailwind-merge: "npm:2.2.1"
     tailwindcss: "npm:3.3.6"
     tailwindcss-animate: "npm:1.0.7"
     ts-node: "npm:10.9.2"
@@ -15005,12 +15005,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tailwind-merge@npm:2.2.0":
-  version: 2.2.0
-  resolution: "tailwind-merge@npm:2.2.0"
+"tailwind-merge@npm:2.2.1":
+  version: 2.2.1
+  resolution: "tailwind-merge@npm:2.2.1"
   dependencies:
-    "@babel/runtime": "npm:^7.23.5"
-  checksum: 41476d686af101c770401f4db509ffea9ec13bf99fd18185903dd86df2b71b3f512d9373b0f2785cb9e9abf093f39373327a29e9b3dde643b9daf7062f77c4ba
+    "@babel/runtime": "npm:^7.23.7"
+  checksum: 14ab965ec897e9377484b7593f7a700dde09b8035b762ad42652622a3ed1f202b203f48c0f235c0b1b38e9390470d94458f6f9010d33a5a18d71b15f38b986a6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Remove the CSS variables that were added by shadcn, update the shadcn components configuration, and re-build the ui components.
- In the globals.css, apply a default background color and text color. This allows us to remove the background color and text color sets in pages and components where we should just use the defaults.
- Add storybook stories for all the UI components