### PR TITLE
feat: books api

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -14,7 +14,6 @@ const config: Config = {
     '<rootDir>/test-setup/fetch-polyfill.setup.ts',
     '<rootDir>/test-setup/prisma-mock.setup.ts',
   ],
-  testEnvironment: 'jsdom',
 };
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async

--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
     "react-dom": "18.2.0",
     "react-hook-form": "7.48.2",
     "tailwind-merge": "2.2.1",
-    "tailwindcss-animate": "1.0.7"
+    "tailwindcss-animate": "1.0.7",
+    "zod": "3.22.4",
+    "zod-validation-error": "3.0.0"
   },
   "devDependencies": {
     "@storybook/addon-essentials": "7.6.10",

--- a/src/app/api/books/route.test.ts
+++ b/src/app/api/books/route.test.ts
@@ -1,0 +1,87 @@
+import { GET } from '@/app/api/books/route';
+import { NextRequest } from 'next/server';
+
+const mockGetBooks = jest.fn();
+jest.mock('../../../lib/actions/book', () => ({
+  getBooks: (...args: unknown[]) => mockGetBooks(...args),
+}));
+
+function buildUrl(path: string): string {
+  return `http://domain${path}`;
+}
+function buildBooksUrl(query?: string): string {
+  return buildUrl(`/api/books${query ? `?${query}` : ''}`);
+}
+
+describe('/api/books', () => {
+  beforeEach(() => {
+    mockGetBooks.mockReset();
+  });
+
+  describe('GET', () => {
+    it('success with 0 search parameters', async () => {
+      mockGetBooks.mockReturnValue({});
+
+      const req = new NextRequest(new Request(buildBooksUrl()), {
+        method: 'GET',
+      });
+      const res = await GET(req);
+
+      expect(mockGetBooks).toHaveBeenCalledWith({
+        paginationQuery: {},
+      });
+      expect(res.status).toEqual(200);
+    });
+
+    it('success with 1 search parameter', async () => {
+      mockGetBooks.mockReturnValue({});
+
+      const req = new NextRequest(new Request(buildBooksUrl('first=1')), {
+        method: 'GET',
+      });
+      const res = await GET(req);
+
+      expect(mockGetBooks).toHaveBeenCalledWith({
+        paginationQuery: {
+          first: 1,
+        },
+      });
+      expect(res.status).toEqual(200);
+    });
+
+    it('success with 2 search parameters', async () => {
+      mockGetBooks.mockReturnValue({});
+
+      const req = new NextRequest(
+        new Request(buildBooksUrl('first=1&after=2')),
+        {
+          method: 'GET',
+        },
+      );
+      const res = await GET(req);
+
+      expect(mockGetBooks).toHaveBeenCalledWith({
+        paginationQuery: {
+          after: '2',
+          first: 1,
+        },
+      });
+      expect(res.status).toEqual(200);
+    });
+
+    it('error with invalid parameters', async () => {
+      mockGetBooks.mockReturnValue({});
+
+      const req = new NextRequest(new Request(buildBooksUrl('first=hi')), {
+        method: 'GET',
+      });
+      const res = await GET(req);
+
+      expect(mockGetBooks).not.toHaveBeenCalled();
+      expect(res.status).toEqual(400);
+      expect(res.statusText).toEqual(
+        'Validation error: Expected number, received nan at "first"',
+      );
+    });
+  });
+});

--- a/src/app/api/books/route.ts
+++ b/src/app/api/books/route.ts
@@ -1,0 +1,40 @@
+import { getBooks } from '@/lib/actions/book';
+import { NextRequest } from 'next/server';
+import { z } from 'zod';
+import { fromZodError } from 'zod-validation-error';
+
+const schema = z.object({
+  after: z.string().optional().nullable(),
+  before: z.string().optional().nullable(),
+  first: z.coerce.number().optional().nullable(),
+  last: z.coerce.number().optional().nullable(),
+});
+
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const params = Object.fromEntries(searchParams.entries());
+  const { after, before, first, last } = params;
+
+  const validatedFields = schema.safeParse({
+    after,
+    before,
+    first,
+    last,
+  });
+
+  if (!validatedFields.success) {
+    const message = fromZodError(validatedFields.error);
+    return new Response(null, {
+      status: 400,
+      statusText: message.toString(),
+    });
+  }
+
+  const response = await getBooks({
+    paginationQuery: {
+      ...validatedFields.data,
+    },
+  });
+
+  return Response.json(response);
+}

--- a/src/lib/pagination.test.ts
+++ b/src/lib/pagination.test.ts
@@ -8,6 +8,7 @@ import {
   buildFullPaginationQuery,
   buildPaginationRequest,
   buildPaginationResponse,
+  findTake,
 } from '@/lib/pagination';
 import PaginationQuery from '@/types/PaginationQuery';
 
@@ -65,6 +66,14 @@ describe('pagination', () => {
         first: 1,
         last: 2,
         title: 'should fail when both first and last are supplied',
+      },
+      {
+        after: null,
+        before: null,
+        expected: true,
+        first: NaN,
+        last: Infinity,
+        title: 'should pass when both first and last are NaN (ignoring them)',
       },
       {
         after: null,
@@ -191,6 +200,24 @@ describe('pagination', () => {
       expect(findLimit(nullPaginationQuery)).toEqual(DEFAULT_LIMIT);
     });
 
+    it('should use default when first is NaN/Infinity', () => {
+      expect(
+        findLimit({
+          ...nullPaginationQuery,
+          first: NaN,
+        }),
+      ).toEqual(DEFAULT_LIMIT);
+    });
+
+    it('should use default when last is NaN/Infinity', () => {
+      expect(
+        findLimit({
+          ...nullPaginationQuery,
+          last: Infinity,
+        }),
+      ).toEqual(DEFAULT_LIMIT);
+    });
+
     it('should use first when supplied', () => {
       expect(
         findLimit({
@@ -222,6 +249,35 @@ describe('pagination', () => {
           first: undefined as unknown as number,
         }),
       ).toEqual(DEFAULT_LIMIT);
+    });
+  });
+
+  describe('findTake', () => {
+    it('should return 1 more when limit is positive', () => {
+      expect(
+        findTake({
+          ...nullPaginationQuery,
+          first: 1,
+        }),
+      ).toEqual(2);
+    });
+
+    it('should return 1 less when limit is negative', () => {
+      expect(
+        findTake({
+          ...nullPaginationQuery,
+          last: 3,
+        }),
+      ).toEqual(-4);
+    });
+
+    it('should return 0 when limit is 0', () => {
+      expect(
+        findTake({
+          ...nullPaginationQuery,
+          first: 0,
+        }),
+      ).toEqual(0);
     });
   });
 

--- a/src/lib/pagination.ts
+++ b/src/lib/pagination.ts
@@ -28,7 +28,7 @@ export function isValidPaginationQuery(
 
   if (before && after) {
     return false;
-  } else if (_.isNumber(first) && _.isNumber(last)) {
+  } else if (_.isFinite(first) && _.isFinite(last)) {
     return false;
   }
 
@@ -57,9 +57,10 @@ export function parseCursorAsId(
 export function findLimit(paginationQuery: PaginationQuery): number {
   const { first, last } = paginationQuery;
 
-  if (_.isNumber(first)) {
+  // need to also include isNumber to make typescript happy
+  if (_.isNumber(first) && _.isFinite(first)) {
     return first;
-  } else if (_.isNumber(last)) {
+  } else if (_.isNumber(last) && _.isFinite(last)) {
     return -last;
   } else {
     return DEFAULT_LIMIT;
@@ -68,8 +69,9 @@ export function findLimit(paginationQuery: PaginationQuery): number {
 
 export function findTake(paginationQuery: PaginationQuery): number {
   const limit = findLimit(paginationQuery);
+  logger.trace('limit: %j', limit);
   // add or subtract 1 to verify if we have next page
-  const take = limit > 0 ? limit + 1 : limit - 1;
+  const take = limit === 0 ? 0 : limit > 0 ? limit + 1 : limit - 1;
 
   return take;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6250,6 +6250,8 @@ __metadata:
     tailwindcss-animate: "npm:1.0.7"
     ts-node: "npm:10.9.2"
     typescript: "npm:5.3.3"
+    zod: "npm:3.22.4"
+    zod-validation-error: "npm:3.0.0"
   languageName: unknown
   linkType: soft
 
@@ -16440,5 +16442,21 @@ __metadata:
   version: 1.0.0
   resolution: "yocto-queue@npm:1.0.0"
   checksum: 856117aa15cf5103d2a2fb173f0ab4acb12b4b4d0ed3ab249fdbbf612e55d1cadfd27a6110940e24746fb0a78cf640b522cc8bca76f30a3b00b66e90cf82abe0
+  languageName: node
+  linkType: hard
+
+"zod-validation-error@npm:3.0.0":
+  version: 3.0.0
+  resolution: "zod-validation-error@npm:3.0.0"
+  peerDependencies:
+    zod: ^3.18.0
+  checksum: b85590173bb9c7ca6a4996930cce560567033eacc2bf91635b79c4467938dd9363bd0e36ad79f120c880632fdbfaccf92284ae12dc5a2e6d592d352050bb246f
+  languageName: node
+  linkType: hard
+
+"zod@npm:3.22.4":
+  version: 3.22.4
+  resolution: "zod@npm:3.22.4"
+  checksum: 7578ab283dac0eee66a0ad0fc4a7f28c43e6745aadb3a529f59a4b851aa10872b3890398b3160f257f4b6817b4ce643debdda4fb21a2c040adda7862cab0a587
   languageName: node
   linkType: hard


### PR DESCRIPTION
- Add the first API, which will return the list of books
- Update some of the pagination code after finding some error paths in testing. Add tests to cover.
- Switch the jest test environment to default to "node" since the route test requires that, and the other tests don't mind (at this point).