### PR TITLE
feat: seed data

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -6,6 +6,10 @@ const nextConfig = {
         hostname: 'books.google.com',
         protocol: 'https',
       },
+      {
+        hostname: 'picsum.photos',
+        protocol: 'https',
+      },
     ],
   },
 };

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "zod-validation-error": "3.0.0"
   },
   "devDependencies": {
+    "@faker-js/faker": "8.4.1",
     "@playwright/test": "1.41.2",
     "@storybook/addon-essentials": "7.6.10",
     "@storybook/addon-interactions": "7.6.10",

--- a/src/components/stories/Books.stories.tsx
+++ b/src/components/stories/Books.stories.tsx
@@ -1,6 +1,7 @@
 import Books from '@/components/Books';
 import BookType from '@/types/Book';
 import type { Meta, StoryObj } from '@storybook/react';
+import _ from 'lodash';
 
 const meta: Meta<typeof Books> = {
   component: Books,
@@ -9,10 +10,13 @@ const meta: Meta<typeof Books> = {
 export default meta;
 type Story = StoryObj<typeof Books>;
 
+const randomImage = (): string =>
+  `https://picsum.photos/id/${_.random(1, 500)}/128/192`;
+
 const book1: BookType = {
   author: 'Biff Spiffington',
   genre: 'Fiction',
-  imageUrl: 'https://picsum.photos/128/192',
+  imageUrl: randomImage(),
   isbn: '123',
   publishedDate: new Date('2000-01-02'),
   publisher: 'My Publisher',
@@ -22,7 +26,7 @@ const book1: BookType = {
 const book2: BookType = {
   author: 'Jane Doe',
   genre: 'Non-Fiction',
-  imageUrl: 'https://picsum.photos/128/192',
+  imageUrl: randomImage(),
   isbn: '345',
   publishedDate: new Date('2001-02-03'),
   publisher: 'My Other Publisher',
@@ -32,7 +36,7 @@ const book2: BookType = {
 const book3: BookType = {
   author: 'John Doe',
   genre: 'Fiction',
-  imageUrl: 'https://picsum.photos/128/192',
+  imageUrl: randomImage(),
   isbn: '567',
   publishedDate: new Date('2002-03-04'),
   publisher: 'That Publisher',

--- a/src/lib/pagination.ts
+++ b/src/lib/pagination.ts
@@ -4,7 +4,7 @@ import PaginationQuery from '@/types/PaginationQuery';
 import { Prisma } from '@prisma/client';
 import _ from 'lodash';
 
-export const DEFAULT_LIMIT = 3;
+export const DEFAULT_LIMIT = 10;
 
 /* ***********************************************
  * PAGINATION REQUEST

--- a/yarn.lock
+++ b/yarn.lock
@@ -1888,6 +1888,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@faker-js/faker@npm:8.4.1":
+  version: 8.4.1
+  resolution: "@faker-js/faker@npm:8.4.1"
+  checksum: 4f2aecddcfdc2cc8b50b2d15d1e37302a7c7a5bbd184ae910a9d271bc11248533ca74dcdd4a9ccbe20410553e7af0f6a4d334c5b955635e09a32ddf4a64942d4
+  languageName: node
+  linkType: hard
+
 "@fal-works/esbuild-plugin-global-externals@npm:^2.1.2":
   version: 2.1.2
   resolution: "@fal-works/esbuild-plugin-global-externals@npm:2.1.2"
@@ -6167,6 +6174,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "bookstore@workspace:."
   dependencies:
+    "@faker-js/faker": "npm:8.4.1"
     "@playwright/test": "npm:1.41.2"
     "@prisma/client": "npm:5.8.1"
     "@radix-ui/react-icons": "npm:1.3.0"


### PR DESCRIPTION
- Add code to generate random seed data with variables controlling the amount of sources, authors, and books.
- The placeholder image site doesn't generate random images for the same image on the page. So select a random image from their site instead.
- Increase the default pagination limit to 10 with this additional data.