### PR TITLE
chore: silent logger during tests

### DIFF
--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -6,7 +6,7 @@ const options: LoggerOptions = {
     asObject: true,
   },
   // "silent" to disable logging
-  level: 'trace',
+  level: process.env.NODE_ENV === 'test' ? 'silent' : 'trace',
 };
 
 const logger = pino(options);


### PR DESCRIPTION
- The log messages made reading test output difficult. So change the default behavior to hide log output during tests.