### PR TITLE
chore: parse BigInt for serialization in nextjs

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,10 @@
+// Some of our data types are BigInts, so override toJSON to handle
+// the failure to serialize: "Do not know how to serialize a BigInt"
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt#use_within_json
+BigInt.prototype.toJSON = function () {
+  return this.toString();
+};
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {


### PR DESCRIPTION
When the API responds with a value that includes a BigInt, it needs to parse it to JSON. This fails because JSON.stringify does not yet support BigInt. So provide an override as instructed by MDN. Include this in the next config so that it will be applied within the next framework (which includes the APIs).