### PR TITLE
feat: BookSource isPublisher/isVendor

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:watch": "jest --watch"
   },
   "prisma": {
-    "seed": "ts-node --compiler-options {\"module\":\"CommonJS\"} prisma/seed.ts"
+    "seed": "ts-node -r tsconfig-paths/register --compiler-options {\"module\":\"CommonJS\"} prisma/seed.ts"
   },
   "dependencies": {
     "@prisma/client": "5.8.1",

--- a/prisma/migrations/20240214224631_book_source_publisher_vendor/migration.sql
+++ b/prisma/migrations/20240214224631_book_source_publisher_vendor/migration.sql
@@ -1,0 +1,10 @@
+/*
+  Warnings:
+
+  - Added the required column `isPublisher` to the `BookSource` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `isVendor` to the `BookSource` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "BookSource" ADD COLUMN     "isPublisher" BOOLEAN NOT NULL,
+ADD COLUMN     "isVendor" BOOLEAN NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -38,8 +38,10 @@ model Author {
 }
 
 model BookSource {
-  id   Int    @id @default(autoincrement())
-  name String
+  id          Int     @id @default(autoincrement())
+  name        String
+  isPublisher Boolean
+  isVendor    Boolean
 
   books       Book[] @relation("publisher")
   vendorBooks Book[] @relation("vendor")

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,4 +1,5 @@
-import { randomBook } from '../src/lib/fakes/book';
+import { randomBook } from '@/lib/fakes/book';
+import { randomBookSource } from '@/lib/fakes/book-source';
 import { faker } from '@faker-js/faker';
 import { Author, BookSource, PrismaClient } from '@prisma/client';
 import _ from 'lodash';
@@ -17,10 +18,10 @@ const NUM_BOOKS = 50;
 // ***********************************************************
 
 async function generateSource() {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { id, ...data } = randomBookSource();
   return await prisma.bookSource.create({
-    data: {
-      name: faker.company.name(),
-    },
+    data,
   });
 }
 

--- a/src/lib/actions/book.test.ts
+++ b/src/lib/actions/book.test.ts
@@ -54,6 +54,8 @@ describe('book actions', () => {
           publisher: {
             connectOrCreate: {
               create: {
+                isPublisher: true,
+                isVendor: false,
                 name: 'publisher2',
               },
               where: { id: -1 },
@@ -63,6 +65,8 @@ describe('book actions', () => {
           vendor: {
             connectOrCreate: {
               create: {
+                isPublisher: false,
+                isVendor: true,
                 name: 'vendor3',
               },
               where: { id: -1 },

--- a/src/lib/actions/book.ts
+++ b/src/lib/actions/book.ts
@@ -24,6 +24,7 @@ export async function createBook(book: BookCreateInput): Promise<BookHydrated> {
     where: { name: book.publisher },
   });
 
+  // TODO vendor should come as input
   const vendor = await prisma.bookSource.findFirst({
     where: { name: book.vendor },
   });
@@ -47,6 +48,9 @@ export async function createBook(book: BookCreateInput): Promise<BookHydrated> {
       publisher: {
         connectOrCreate: {
           create: {
+            // TODO we need better logic to determine if publisher/vendor
+            isPublisher: true,
+            isVendor: false,
             name: book.publisher,
           },
           // TODO fixme
@@ -57,6 +61,9 @@ export async function createBook(book: BookCreateInput): Promise<BookHydrated> {
       vendor: {
         connectOrCreate: {
           create: {
+            // TODO we need better logic to determine if publisher/vendor
+            isPublisher: false,
+            isVendor: true,
             name: book.vendor,
           },
           // TODO fixme

--- a/src/lib/fakes/book-source.ts
+++ b/src/lib/fakes/book-source.ts
@@ -2,5 +2,22 @@ import { faker } from '@faker-js/faker';
 import { BookSource } from '@prisma/client';
 
 export function randomBookSource(): BookSource {
-  return { id: faker.number.int(), name: faker.company.name() };
+  let isPublisher = faker.datatype.boolean();
+  let isVendor = faker.datatype.boolean();
+
+  // at least one of these must be true
+  if (!isPublisher && !isVendor) {
+    if (Math.random() > 0.5) {
+      isPublisher = true;
+    } else {
+      isVendor = true;
+    }
+  }
+
+  return {
+    id: faker.number.int(),
+    isPublisher,
+    isVendor,
+    name: faker.company.name(),
+  };
 }

--- a/src/lib/fakes/book.ts
+++ b/src/lib/fakes/book.ts
@@ -1,10 +1,8 @@
+import { randomBookSource } from '@/lib/fakes/book-source';
 import BookHydrated from '@/types/BookHydrated';
 import { faker } from '@faker-js/faker';
 import { Book, Format, Genre } from '@prisma/client';
 import _ from 'lodash';
-
-// must import relative path for seeds!
-import { randomBookSource } from './book-source';
 
 const formatKeys = Object.keys(Format) as Format[];
 export const randomFormat = (): Format => _.sample(formatKeys) as Format;


### PR DESCRIPTION
- Add migration to include isPublisher and isVendor on a BookSource. Still have no data so no need for a migration of data.
- Got annoyed with needing to specify relative paths for seed script dependencies, so found a way to include the tsconfig paths in the command. Replaced relative path imports with configured ones.