### PR TITLE
feat: update create book form

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -12,11 +12,13 @@ const config: Config = {
     'src/**/*.ts*',
     '!src/app/**/layout.tsx',
     '!src/app/**/page.tsx',
+    '!src/app/**/*Container.tsx',
     '!src/lib/fakes/**',
     '!src/types/**',
   ],
   coveragePathIgnorePatterns: [
     'src/components/*',
+    'src/lib/logger.ts',
     'src/lib/prisma.ts',
     'src/lib/tailwind-utils.ts',
   ],

--- a/src/app/add/VendorContainer.tsx
+++ b/src/app/add/VendorContainer.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import VendorSelect from '@/components/book-source/VendorSelect';
+import { BookSource } from '@prisma/client';
+import { getBookSources } from '@/lib/actions/book-source';
+import { VendorCreateFormInput } from '@/components/book-source/VendorCreate';
+
+export default function VendorContainer({
+  hasError,
+  onSelect,
+}: {
+  hasError?: boolean;
+  onSelect: (value: number) => void;
+}) {
+  const [vendors, setVendors] = useState<Array<BookSource>>([]);
+
+  const loadVendors = useCallback(async () => {
+    const { bookSources: vendors } = await getBookSources({
+      paginationQuery: {
+        // TODO need to find a way to solve this
+        first: 100,
+      },
+    });
+    setVendors(vendors);
+  }, []);
+
+  useEffect(() => {
+    loadVendors();
+  }, [loadVendors]);
+
+  const onVendorCreate = useCallback(async (data: VendorCreateFormInput) => {
+    // TODO implement create vendor call
+    console.log(data);
+  }, []);
+
+  return (
+    <>
+      <h2 className="my-2">Vendor</h2>
+      <VendorSelect
+        hasError={hasError}
+        onSelect={onSelect}
+        onVendorCreate={(data) => onVendorCreate(data)}
+        vendors={vendors}
+      />
+    </>
+  );
+}

--- a/src/lib/actions/book.test.ts
+++ b/src/lib/actions/book.test.ts
@@ -15,25 +15,24 @@ describe('book actions', () => {
     it('should create a new book', async () => {
       prismaMock.author.findFirst.mockResolvedValue(null);
       prismaMock.bookSource.findFirst.mockResolvedValue(null);
+      prismaMock.bookSource.findUniqueOrThrow.mockResolvedValue(book1.vendor);
       prismaMock.book.create.mockResolvedValue(book1);
 
       const result = await createBook({
         ...book1,
         authors: 'author1',
         publisher: 'publisher2',
-        vendor: 'vendor3',
       });
 
       expect(prismaMock.author.findFirst).toHaveBeenCalledWith({
         where: { name: 'author1' },
       });
 
-      expect(prismaMock.bookSource.findFirst).toHaveBeenCalledTimes(2);
-      expect(prismaMock.bookSource.findFirst).toHaveBeenNthCalledWith(1, {
+      expect(prismaMock.bookSource.findFirst).toHaveBeenCalledWith({
         where: { name: 'publisher2' },
       });
-      expect(prismaMock.bookSource.findFirst).toHaveBeenNthCalledWith(2, {
-        where: { name: 'vendor3' },
+      expect(prismaMock.bookSource.findUniqueOrThrow).toHaveBeenCalledWith({
+        where: { id: book1.vendorId },
       });
 
       expect(prismaMock.book.create).toHaveBeenCalledWith({
@@ -63,13 +62,8 @@ describe('book actions', () => {
           },
           title: book1.title,
           vendor: {
-            connectOrCreate: {
-              create: {
-                isPublisher: false,
-                isVendor: true,
-                name: 'vendor3',
-              },
-              where: { id: -1 },
+            connect: {
+              id: book1.vendorId,
             },
           },
         },

--- a/src/lib/actions/book.ts
+++ b/src/lib/actions/book.ts
@@ -24,9 +24,10 @@ export async function createBook(book: BookCreateInput): Promise<BookHydrated> {
     where: { name: book.publisher },
   });
 
-  // TODO vendor should come as input
-  const vendor = await prisma.bookSource.findFirst({
-    where: { name: book.vendor },
+  const vendor = await prisma.bookSource.findUniqueOrThrow({
+    where: {
+      id: book.vendorId,
+    },
   });
 
   const createdBook = await prisma.book.create({
@@ -59,15 +60,8 @@ export async function createBook(book: BookCreateInput): Promise<BookHydrated> {
       },
       title: book.title,
       vendor: {
-        connectOrCreate: {
-          create: {
-            // TODO we need better logic to determine if publisher/vendor
-            isPublisher: false,
-            isVendor: true,
-            name: book.vendor,
-          },
-          // TODO fixme
-          where: { id: vendor?.id ?? -1 },
+        connect: {
+          id: vendor.id,
         },
       },
     },

--- a/src/types/BookCreateInput.ts
+++ b/src/types/BookCreateInput.ts
@@ -1,9 +1,8 @@
 import { Book } from '@prisma/client';
 
-type BookCreateInput = Omit<Book, 'id' | 'publisherId' | 'vendorId'> & {
+type BookCreateInput = Omit<Book, 'id' | 'publisherId'> & {
   // TODO this should accept IDs rather than strings
   authors: string;
   publisher: string;
-  vendor: string;
 };
 export default BookCreateInput;


### PR DESCRIPTION
Require the vendor to be selected and use the vendor ID in place of the vendor string when creating a book. This improves the reliability of book creation (by finding by ID) while also more closely aligning with the Receiving flow.

Some specifics:
- Vendor string is no longer the book create input, but vendor ID is once again required.
- Pull some of the vendor specific UI logic into a VendorContainer component. This handles the business logic while using the Vendor-specific components.
- Remove some unnecessary files from code coverage