### PR TITLE
feat: upsert book

### DIFF
--- a/src/app/add/page.tsx
+++ b/src/app/add/page.tsx
@@ -13,7 +13,7 @@ import Search from '@/components/search/Search';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { ReloadIcon } from '@radix-ui/react-icons';
-import { createBook } from '@/lib/actions/book';
+import { upsertBook } from '@/lib/actions/book';
 import useExternalBookSearch, {
   ExternalBookSearchResult,
 } from '@/lib/search/external/useExternalBookSearch';
@@ -91,7 +91,7 @@ export default function AddBookPage() {
         return;
       }
 
-      await createBook({
+      await upsertBook({
         ...book,
         // TODO fixme
         format: Format.HARDCOVER,

--- a/src/lib/actions/book.test.ts
+++ b/src/lib/actions/book.test.ts
@@ -4,6 +4,7 @@ import {
   createBook,
   findBookBySearchString,
   getBooks,
+  upsertBook,
 } from '@/lib/actions/book';
 import { prismaMock } from '../../../test-setup/prisma-mock.setup';
 import { randomBookHydrated } from '@/lib/fakes/book';
@@ -140,6 +141,90 @@ describe('book actions', () => {
           authors: true,
           publisher: true,
           vendor: true,
+        },
+      });
+
+      expect(result).toEqual(book1);
+    });
+  });
+
+  describe('upsertBook', () => {
+    it('should provide the correct data', async () => {
+      prismaMock.author.findFirst.mockResolvedValue(null);
+      prismaMock.bookSource.findFirst.mockResolvedValue(null);
+      prismaMock.bookSource.findUniqueOrThrow.mockResolvedValue(book1.vendor);
+      prismaMock.book.upsert.mockResolvedValue(book1);
+
+      const result = await upsertBook({
+        ...book1,
+        authors: 'author1',
+        publisher: 'publisher2',
+      });
+
+      expect(prismaMock.book.upsert).toHaveBeenCalledWith({
+        create: {
+          authors: {
+            connect: [],
+            create: [
+              {
+                name: 'author1',
+              },
+            ],
+          },
+          format: book1.format,
+          genre: book1.genre,
+          imageUrl: book1.imageUrl,
+          isbn13: book1.isbn13,
+          publishedDate: book1.publishedDate,
+          publisher: {
+            create: {
+              isPublisher: true,
+              isVendor: false,
+              name: 'publisher2',
+            },
+          },
+          title: book1.title,
+          vendor: {
+            connect: {
+              id: book1.vendorId,
+            },
+          },
+        },
+        include: {
+          authors: true,
+          publisher: true,
+          vendor: true,
+        },
+        update: {
+          authors: {
+            connect: [],
+            create: [
+              {
+                name: 'author1',
+              },
+            ],
+          },
+          format: book1.format,
+          genre: book1.genre,
+          imageUrl: book1.imageUrl,
+          isbn13: book1.isbn13,
+          publishedDate: book1.publishedDate,
+          publisher: {
+            create: {
+              isPublisher: true,
+              isVendor: false,
+              name: 'publisher2',
+            },
+          },
+          title: book1.title,
+          vendor: {
+            connect: {
+              id: book1.vendorId,
+            },
+          },
+        },
+        where: {
+          isbn13: book1.isbn13,
         },
       });
 


### PR DESCRIPTION
- add a function to upsert a book
- switch the Add page to use the upsert method instead of create. This moves us closer to the receiving flow where the user would scan the same book multiple times (only the first time would create, subsequent would add quantity).