### PR TITLE
feat: Add invoices to db schema

### DIFF
--- a/prisma/migrations/20240219214941_invoices/migration.sql
+++ b/prisma/migrations/20240219214941_invoices/migration.sql
@@ -1,0 +1,49 @@
+-- DropForeignKey
+ALTER TABLE "Book"
+DROP CONSTRAINT "Book_vendorId_fkey";
+
+-- AlterTable
+ALTER TABLE "Book"
+DROP COLUMN "vendorId",
+ADD COLUMN     "quantity" INTEGER NOT NULL DEFAULT 0;
+
+-- AlterTable
+ALTER TABLE "BookSource"
+ADD COLUMN     "accountNumber" TEXT,
+ADD COLUMN     "discountPercentage" DECIMAL(5,4),
+ADD CONSTRAINT "DiscountPercentageAboveZero" CHECK ("discountPercentage" > 0),
+ADD CONSTRAINT "DiscountPercentageBelowOne" CHECK ("discountPercentage" < 1);
+
+-- CreateTable
+CREATE TABLE "Invoice" (
+    "id" SERIAL NOT NULL,
+    "createdAt" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMPTZ(3),
+    "invoiceId" TEXT NOT NULL,
+    "invoiceDate" TIMESTAMPTZ(1) NOT NULL,
+    "processed" BOOLEAN NOT NULL DEFAULT FALSE,
+    "vendorId" INTEGER NOT NULL,
+
+    CONSTRAINT "Invoice_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "InvoiceItem" (
+    "id" SERIAL NOT NULL,
+    "createdAt" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMPTZ(3),
+    "costInCents" INTEGER NOT NULL,
+    "bookId" INTEGER NOT NULL,
+    "invoiceId" INTEGER NOT NULL,
+
+    CONSTRAINT "InvoiceItem_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "Invoice" ADD CONSTRAINT "Invoice_vendorId_fkey" FOREIGN KEY ("vendorId") REFERENCES "BookSource"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "InvoiceItem" ADD CONSTRAINT "InvoiceItem_bookId_fkey" FOREIGN KEY ("bookId") REFERENCES "Book"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "InvoiceItem" ADD CONSTRAINT "InvoiceItem_invoiceId_fkey" FOREIGN KEY ("invoiceId") REFERENCES "Invoice"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,14 +22,14 @@ model Book {
 
   authors Author[]
 
-  publisher   BookSource @relation(fields: [publisherId], references: [id], name: "publisher")
+  publisher   BookSource @relation(fields: [publisherId], references: [id])
   publisherId Int
-
-  vendor   BookSource @relation(fields: [vendorId], references: [id], name: "vendor")
-  vendorId Int
 
   format Format
   genre  Genre
+
+  quantity     Int           @default(0)
+  invoiceItems InvoiceItem[]
 }
 
 model Author {
@@ -42,15 +42,45 @@ model Author {
 }
 
 model BookSource {
+  id        Int       @id @default(autoincrement())
+  createdAt DateTime  @default(now()) @db.Timestamptz(3)
+  updatedAt DateTime? @updatedAt @db.Timestamptz(3)
+  name      String
+
+  isPublisher Boolean
+  books       Book[]
+
+  isVendor           Boolean
+  accountNumber      String?
+  discountPercentage Decimal?  @db.Decimal(5, 4)
+  invoices           Invoice[]
+}
+
+model Invoice {
   id          Int       @id @default(autoincrement())
   createdAt   DateTime  @default(now()) @db.Timestamptz(3)
   updatedAt   DateTime? @updatedAt @db.Timestamptz(3)
-  name        String
-  isPublisher Boolean
-  isVendor    Boolean
+  invoiceId   String
+  invoiceDate DateTime  @db.Timestamptz(1)
+  processed   Boolean   @default(false)
 
-  books       Book[] @relation("publisher")
-  vendorBooks Book[] @relation("vendor")
+  vendor   BookSource @relation(fields: [vendorId], references: [id])
+  vendorId Int
+
+  invoiceItems InvoiceItem[]
+}
+
+model InvoiceItem {
+  id          Int       @id @default(autoincrement())
+  createdAt   DateTime  @default(now()) @db.Timestamptz(3)
+  updatedAt   DateTime? @updatedAt @db.Timestamptz(3)
+  costInCents Int
+
+  book   Book @relation(fields: [bookId], references: [id])
+  bookId Int
+
+  invoice   Invoice @relation(fields: [invoiceId], references: [id])
+  invoiceId Int
 }
 
 enum Format {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -55,7 +55,7 @@ async function generateBook(props: GenerateBookProps) {
   }));
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { id, publisherId, vendorId, ...data } = randomBook();
+  const { id, publisherId, ...data } = randomBook();
 
   return await prisma.book.create({
     data: {
@@ -65,9 +65,6 @@ async function generateBook(props: GenerateBookProps) {
       },
       publisher: {
         connect: props.publisher,
-      },
-      vendor: {
-        connect: props.vendor,
       },
     },
   });

--- a/src/app/add/page.tsx
+++ b/src/app/add/page.tsx
@@ -86,6 +86,7 @@ export default function AddBookPage() {
 
   const onSubmit: SubmitHandler<AddBookFormInput> = useCallback(
     async (book) => {
+      // TODO fixme
       if (!vendorId) {
         setError(`root.${ERROR_KEY_VENDOR}`, { type: 'required' });
         return;
@@ -99,7 +100,8 @@ export default function AddBookPage() {
         genre: Genre.FANTASY,
         isbn13: BigInt(book.isbn13),
         publishedDate: new Date(book.publishedDate),
-        vendorId,
+        // TODO fixme
+        quantity: 0,
       });
       reset();
       setLookupBook(null);

--- a/src/lib/actions/book.test.ts
+++ b/src/lib/actions/book.test.ts
@@ -89,7 +89,6 @@ describe('book actions', () => {
     it('should create a new book', async () => {
       prismaMock.author.findFirst.mockResolvedValue(null);
       prismaMock.bookSource.findFirst.mockResolvedValue(null);
-      prismaMock.bookSource.findUniqueOrThrow.mockResolvedValue(book1.vendor);
       prismaMock.book.create.mockResolvedValue(book1);
 
       const result = await createBook({
@@ -104,9 +103,6 @@ describe('book actions', () => {
 
       expect(prismaMock.bookSource.findFirst).toHaveBeenCalledWith({
         where: { name: 'publisher2' },
-      });
-      expect(prismaMock.bookSource.findUniqueOrThrow).toHaveBeenCalledWith({
-        where: { id: book1.vendorId },
       });
 
       expect(prismaMock.book.create).toHaveBeenCalledWith({
@@ -131,17 +127,12 @@ describe('book actions', () => {
               name: 'publisher2',
             },
           },
+          quantity: book1.quantity,
           title: book1.title,
-          vendor: {
-            connect: {
-              id: book1.vendorId,
-            },
-          },
         },
         include: {
           authors: true,
           publisher: true,
-          vendor: true,
         },
       });
 
@@ -153,7 +144,6 @@ describe('book actions', () => {
     it('should provide the correct data', async () => {
       prismaMock.author.findFirst.mockResolvedValue(null);
       prismaMock.bookSource.findFirst.mockResolvedValue(null);
-      prismaMock.bookSource.findUniqueOrThrow.mockResolvedValue(book1.vendor);
       prismaMock.book.upsert.mockResolvedValue(book1);
 
       const result = await upsertBook({
@@ -184,17 +174,12 @@ describe('book actions', () => {
               name: 'publisher2',
             },
           },
+          quantity: book1.quantity,
           title: book1.title,
-          vendor: {
-            connect: {
-              id: book1.vendorId,
-            },
-          },
         },
         include: {
           authors: true,
           publisher: true,
-          vendor: true,
         },
         update: {
           authors: {
@@ -217,12 +202,8 @@ describe('book actions', () => {
               name: 'publisher2',
             },
           },
+          quantity: book1.quantity,
           title: book1.title,
-          vendor: {
-            connect: {
-              id: book1.vendorId,
-            },
-          },
         },
         where: {
           isbn13: book1.isbn13,
@@ -282,7 +263,6 @@ describe('book actions', () => {
         include: {
           authors: true,
           publisher: true,
-          vendor: true,
         },
         where: {
           OR: [
@@ -306,7 +286,6 @@ describe('book actions', () => {
         include: {
           authors: true,
           publisher: true,
-          vendor: true,
         },
         where: { isbn13 },
       });

--- a/src/lib/actions/book.ts
+++ b/src/lib/actions/book.ts
@@ -76,12 +76,6 @@ async function buildCreateUpdateBookData(
 
   const publisher = await buildPublisherInput(book.publisher);
 
-  const vendor = await prisma.bookSource.findUniqueOrThrow({
-    where: {
-      id: book.vendorId,
-    },
-  });
-
   return {
     authors,
     format: book.format,
@@ -90,12 +84,8 @@ async function buildCreateUpdateBookData(
     isbn13: book.isbn13,
     publishedDate: book.publishedDate,
     publisher,
+    quantity: book.quantity,
     title: book.title,
-    vendor: {
-      connect: {
-        id: vendor.id,
-      },
-    },
   };
 }
 
@@ -111,7 +101,6 @@ export async function createBook(book: BookCreateInput): Promise<BookHydrated> {
     include: {
       authors: true,
       publisher: true,
-      vendor: true,
     },
   });
 
@@ -130,7 +119,6 @@ export async function upsertBook(book: BookCreateInput): Promise<BookHydrated> {
     include: {
       authors: true,
       publisher: true,
-      vendor: true,
     },
     update: data as Prisma.BookUpdateInput,
     where: { isbn13: book.isbn13 },
@@ -160,7 +148,6 @@ export async function getBooks({
     include: {
       authors: true,
       publisher: true,
-      vendor: true,
     },
   });
 
@@ -182,7 +169,6 @@ export async function findBookBySearchString(
     include: {
       authors: true,
       publisher: true,
-      vendor: true,
     },
     where: {
       OR: [{ authors: { some: { name: { search } } } }, { title: { search } }],
@@ -200,7 +186,6 @@ export async function getBook(
     include: {
       authors: true,
       publisher: true,
-      vendor: true,
     },
     where: { isbn13 },
   });

--- a/src/lib/fakes/book-source.ts
+++ b/src/lib/fakes/book-source.ts
@@ -17,6 +17,9 @@ export function randomBookSource(): BookSource {
 
   return {
     ...randomCreatedAtUpdatedAt(),
+    // TODO separate out publisher from vendor
+    accountNumber: null,
+    discountPercentage: null,
     id: faker.number.int(),
     isPublisher,
     isVendor,

--- a/src/lib/fakes/book.ts
+++ b/src/lib/fakes/book.ts
@@ -36,14 +36,13 @@ export function randomBook(): Book {
     isbn13: randomIsbn13(),
     publishedDate: faker.date.past(),
     publisherId: faker.number.int(),
+    quantity: 0,
     title: faker.music.songName(),
-    vendorId: faker.number.int(),
   };
 }
 
 export function randomBookHydrated(): BookHydrated {
   const publisher = randomBookSource();
-  const vendor = randomBookSource();
 
   return {
     ...randomCreatedAtUpdatedAt(),
@@ -56,8 +55,7 @@ export function randomBookHydrated(): BookHydrated {
     publishedDate: faker.date.past(),
     publisher,
     publisherId: publisher.id,
+    quantity: 0,
     title: faker.music.songName(),
-    vendor,
-    vendorId: vendor.id,
   };
 }

--- a/src/lib/schemas/book.ts
+++ b/src/lib/schemas/book.ts
@@ -24,6 +24,6 @@ export const BOOK_CREATE_INPUT_SCHEMA: toZod<BookCreateInput> = z.object({
     .pipe(z.bigint()) as unknown as z.ZodBigInt,
   publishedDate: z.coerce.date().nullable(),
   publisher: z.string(),
+  quantity: z.number(),
   title: z.string(),
-  vendorId: z.number(),
 });

--- a/src/types/BookHydrated.ts
+++ b/src/types/BookHydrated.ts
@@ -3,6 +3,5 @@ import { Author, Book, BookSource } from '@prisma/client';
 type BookHydrated = Book & {
   authors: Author[];
   publisher: BookSource;
-  vendor: BookSource;
 };
 export default BookHydrated;


### PR DESCRIPTION
Add the concept of an Invoice to the database schema. Invoices represent receiving a shipment of books from a Vendor. The invoice will contain a list of InvoiceItems, each being a 1-1 with an actual Book. So by processing the Invoice, we'll add inventory to our Books.

This first pass just updates the database and resolves any issues with the code post-update. We'll later come in an add actions to create invoices and eventually update the UI with the new flow.