### PR TITLE
chore: separate out fake vendor/publisher

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,19 @@ Reset the database, re-run migrations, and re-seed the data:
 $ yarn db:reset
 ```
 
+#### Overrides
+
+The seed script provides values for the number of entities to create. These can be overridden via the environment variables:
+
+```
+SEED_NUM_VENDORS
+SEED_NUM_PUBLISHERS
+SEED_NUM_AUTHORS
+SEED_NUM_BOOKS
+```
+
+For instance, to set the number of Books to create to 5, set the environment variable `SEED_NUM_BOOKS=5` prior to running the seed script.
+
 ## Logging
 
 [Pino](https://github.com/pinojs/pino) logger is setup to use within the app. Configuration can be found in the [logger.ts](src/lib/logger.ts) file.

--- a/src/components/stories/book-source/VendorSelect.stories.tsx
+++ b/src/components/stories/book-source/VendorSelect.stories.tsx
@@ -1,5 +1,5 @@
 import VendorSelect from '@/components/book-source/VendorSelect';
-import { randomBookSource } from '@/lib/fakes/book-source';
+import { randomVendor } from '@/lib/fakes/book-source';
 import type { Meta, StoryObj } from '@storybook/react';
 import _ from 'lodash';
 
@@ -10,7 +10,7 @@ const meta: Meta<typeof VendorSelect> = {
 export default meta;
 type Story = StoryObj<typeof VendorSelect>;
 
-const vendors = _.times(5, randomBookSource);
+const vendors = _.times(5, randomVendor);
 
 export const Default: Story = {
   args: {

--- a/src/lib/actions/book-source.test.ts
+++ b/src/lib/actions/book-source.test.ts
@@ -1,11 +1,11 @@
 import { getBookSources } from '@/lib/actions/book-source';
 import { prismaMock } from '../../../test-setup/prisma-mock.setup';
-import { randomBookSource } from '@/lib/fakes/book-source';
+import { randomPublisher, randomVendor } from '@/lib/fakes/book-source';
 
 describe('book actions', () => {
-  const bookSource1 = randomBookSource();
-  const bookSource2 = randomBookSource();
-  const bookSource3 = randomBookSource();
+  const bookSource1 = randomVendor();
+  const bookSource2 = randomPublisher();
+  const bookSource3 = randomPublisher();
 
   describe('getBooks', () => {
     it('should get book sources when provided with default input', async () => {

--- a/src/lib/fakes/book-source.ts
+++ b/src/lib/fakes/book-source.ts
@@ -1,28 +1,32 @@
 import { randomCreatedAtUpdatedAt } from '@/lib/fakes/created-at-updated-at';
 import { faker } from '@faker-js/faker';
-import { BookSource } from '@prisma/client';
+import { BookSource, Prisma } from '@prisma/client';
 
-export function randomBookSource(): BookSource {
-  let isPublisher = faker.datatype.boolean();
-  let isVendor = faker.datatype.boolean();
-
-  // at least one of these must be true
-  if (!isPublisher && !isVendor) {
-    if (Math.random() > 0.5) {
-      isPublisher = true;
-    } else {
-      isVendor = true;
-    }
-  }
-
+export function randomPublisher(): BookSource {
   return {
     ...randomCreatedAtUpdatedAt(),
-    // TODO separate out publisher from vendor
     accountNumber: null,
     discountPercentage: null,
     id: faker.number.int(),
+    isPublisher: true,
+    isVendor: false,
+    name: faker.company.name(),
+  };
+}
+
+export function randomVendor(): BookSource {
+  // some vendors can also be publishers, so randomly assign isPublisher
+  const isPublisher = faker.datatype.boolean();
+
+  return {
+    ...randomCreatedAtUpdatedAt(),
+    accountNumber: faker.finance.accountNumber(),
+    discountPercentage: new Prisma.Decimal(
+      faker.number.float({ fractionDigits: 2 }),
+    ),
+    id: faker.number.int(),
     isPublisher,
-    isVendor,
+    isVendor: true,
     name: faker.company.name(),
   };
 }

--- a/src/lib/fakes/book.ts
+++ b/src/lib/fakes/book.ts
@@ -1,5 +1,5 @@
 import { randomAuthor } from '@/lib/fakes/author';
-import { randomBookSource } from '@/lib/fakes/book-source';
+import { randomPublisher } from '@/lib/fakes/book-source';
 import { randomCreatedAtUpdatedAt } from '@/lib/fakes/created-at-updated-at';
 import BookHydrated from '@/types/BookHydrated';
 import { faker } from '@faker-js/faker';
@@ -42,7 +42,7 @@ export function randomBook(): Book {
 }
 
 export function randomBookHydrated(): BookHydrated {
-  const publisher = randomBookSource();
+  const publisher = randomPublisher();
 
   return {
     ...randomCreatedAtUpdatedAt(),


### PR DESCRIPTION
- the original implementation of the fakes for book sources were generic, this makes either a publisher or vendor and supplies the values for both.
- update the places that use these fakes to use the new versions
- allow seeds to accept values from the environment as overrides to those set in the seed code. Update the readme to describe the process.