### PR TITLE
feat: complete invoice

### DIFF
--- a/src/lib/actions/invoice.test.ts
+++ b/src/lib/actions/invoice.test.ts
@@ -1,9 +1,19 @@
 import { fakeInvoice } from '@/lib/fakes/invoice';
 import { prismaMock } from '../../../test-setup/prisma-mock.setup';
-import { createInvoice } from '@/lib/actions/invoice';
+import { completeInvoice, createInvoice } from '@/lib/actions/invoice';
+import { fakeInvoiceItem } from '@/lib/fakes/invoice-item';
+import { randomBook } from '@/lib/fakes/book';
 
 describe('invoice actions', () => {
-  const invoice = fakeInvoice();
+  const invoice = fakeInvoice(false);
+
+  beforeAll(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2000-02-03T12:00:00.000Z'));
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
 
   describe('createInvoice', () => {
     it('should create a new invoice', async () => {
@@ -21,6 +31,64 @@ describe('invoice actions', () => {
           invoiceItems: true,
           vendor: true,
         },
+      });
+
+      expect(result).toEqual(invoice);
+    });
+  });
+
+  describe('completeInvoice', () => {
+    it('should complete the invoice', async () => {
+      prismaMock.$transaction.mockImplementation((cb) => cb(prismaMock));
+
+      const item1 = fakeInvoiceItem();
+      prismaMock.book.findUniqueOrThrow.mockResolvedValueOnce({
+        ...randomBook(),
+        quantity: 7,
+      });
+      const item2 = fakeInvoiceItem();
+      prismaMock.book.findUniqueOrThrow.mockResolvedValueOnce({
+        ...randomBook(),
+        quantity: 0,
+      });
+      const item3 = fakeInvoiceItem();
+      prismaMock.book.findUniqueOrThrow.mockResolvedValueOnce({
+        ...randomBook(),
+        quantity: 2,
+      });
+      prismaMock.invoiceItem.findMany.mockResolvedValue([item1, item2, item3]);
+      prismaMock.invoice.update.mockResolvedValue(invoice);
+
+      const result = await completeInvoice(invoice.id);
+
+      expect(prismaMock.invoiceItem.findMany).toHaveBeenCalledWith({
+        where: { invoiceId: invoice.id },
+      });
+
+      expect(prismaMock.book.update).toHaveBeenCalledTimes(3);
+      expect(prismaMock.book.update).toHaveBeenNthCalledWith(1, {
+        data: { quantity: item1.quantity + 7 },
+        where: { id: item1.bookId },
+      });
+      expect(prismaMock.book.update).toHaveBeenNthCalledWith(2, {
+        data: { quantity: item2.quantity + 0 },
+        where: { id: item2.bookId },
+      });
+      expect(prismaMock.book.update).toHaveBeenNthCalledWith(3, {
+        data: { quantity: item3.quantity + 2 },
+        where: { id: item3.bookId },
+      });
+
+      expect(prismaMock.invoice.update).toHaveBeenCalledWith({
+        data: {
+          dateReceived: new Date('2000-02-03T12:00:00.000Z'),
+          isCompleted: true,
+        },
+        include: {
+          invoiceItems: true,
+          vendor: true,
+        },
+        where: { id: invoice.id },
       });
 
       expect(result).toEqual(invoice);

--- a/src/lib/actions/invoice.ts
+++ b/src/lib/actions/invoice.ts
@@ -2,6 +2,7 @@ import logger from '@/lib/logger';
 import prisma from '@/lib/prisma';
 import InvoiceCreateInput from '@/types/InvoiceCreateInput';
 import InvoiceHydrated from '@/types/InvoiceHydrated';
+import { Invoice, InvoiceItem, Prisma } from '@prisma/client';
 
 export async function createInvoice(
   invoice: InvoiceCreateInput,
@@ -23,4 +24,50 @@ export async function createInvoice(
   logger.trace('created invoice in DB: %j', createdInvoice);
 
   return createdInvoice;
+}
+
+async function updateBookQuantity(
+  tx: Prisma.TransactionClient,
+  invoiceItem: InvoiceItem,
+): Promise<void> {
+  const { bookId, quantity } = invoiceItem;
+
+  const book = await tx.book.findUniqueOrThrow({
+    where: { id: bookId },
+  });
+
+  await tx.book.update({
+    data: { quantity: book.quantity + quantity },
+    where: { id: bookId },
+  });
+}
+
+export async function completeInvoice(
+  invoiceId: Invoice['id'],
+): Promise<InvoiceHydrated> {
+  const invoiceItems = await prisma.invoiceItem.findMany({
+    where: {
+      invoiceId: invoiceId,
+    },
+  });
+
+  return prisma.$transaction(async (tx) => {
+    logger.trace('updating books for %d invoice items...', invoiceItems.length);
+    await Promise.all(invoiceItems.map((item) => updateBookQuantity(tx, item)));
+
+    logger.trace('marking invoice complete, invoice id: %s', invoiceId);
+    const invoice = await tx.invoice.update({
+      data: {
+        dateReceived: new Date(),
+        isCompleted: true,
+      },
+      include: {
+        invoiceItems: true,
+        vendor: true,
+      },
+      where: { id: invoiceId },
+    });
+
+    return invoice;
+  });
 }


### PR DESCRIPTION
When marking the invoice as complete, we iterate over the invoice items and increase the associated book's quantity with the quantity in the invoice item (we've received this amount of books). Once that's done, we mark the invoice as complete and include today's date.