### PR TITLE
chore: update constraint check

### DIFF
--- a/prisma/migrations/20240219214941_invoices/migration.sql
+++ b/prisma/migrations/20240219214941_invoices/migration.sql
@@ -11,8 +11,8 @@ ADD COLUMN     "quantity" INTEGER NOT NULL DEFAULT 0;
 ALTER TABLE "BookSource"
 ADD COLUMN     "accountNumber" TEXT,
 ADD COLUMN     "discountPercentage" DECIMAL(5,4),
-ADD CONSTRAINT "DiscountPercentageAboveZero" CHECK ("discountPercentage" > 0),
-ADD CONSTRAINT "DiscountPercentageBelowOne" CHECK ("discountPercentage" < 1);
+ADD CONSTRAINT "DiscountPercentageGreaterThanEqualToZero" CHECK ("discountPercentage" >= 0),
+ADD CONSTRAINT "DiscountPercentageLessThanEqualToOne" CHECK ("discountPercentage" <= 1);
 
 -- CreateTable
 CREATE TABLE "Invoice" (


### PR DESCRIPTION
The constraint check needed to be >= or <= rather than > or <. This could have been another migration, but without real data, we can safely update the migration with the error.