### PR TITLE
feat: invoice actions: get

### DIFF
--- a/src/types/InvoiceHydrated.ts
+++ b/src/types/InvoiceHydrated.ts
@@ -1,7 +1,7 @@
-import { BookSource, Invoice, InvoiceItem } from '@prisma/client';
+import { BookSource, Invoice } from '@prisma/client';
 
 type InvoiceHydrated = Invoice & {
-  invoiceItems: InvoiceItem[];
+  numInvoiceItems: number;
   vendor: BookSource;
 };
 export default InvoiceHydrated;


### PR DESCRIPTION
- add action to getInvoices and getInvoice
- we were going to have to return a lot of data just to show the list of invoice items, so instead just return the number of invoice items. In the UI we can separately query for a list of invoice items by invoice ID.