### PR TITLE
feat: book source serializer

### DIFF
--- a/src/lib/actions/invoice.test.ts
+++ b/src/lib/actions/invoice.test.ts
@@ -10,6 +10,10 @@ import { fakeInvoiceItem } from '@/lib/fakes/invoice-item';
 import { fakeBook } from '@/lib/fakes/book';
 import { Invoice } from '@prisma/client';
 
+jest.mock('../serializers/book-source', () => ({
+  serializeBookSource: (vendor: unknown) => vendor,
+}));
+
 describe('invoice actions', () => {
   const invoice1 = fakeInvoice(false);
   const resolvedInvoice1 = {

--- a/src/lib/actions/invoice.ts
+++ b/src/lib/actions/invoice.ts
@@ -6,6 +6,7 @@ import {
   buildPaginationResponse,
 } from '@/lib/pagination';
 import prisma from '@/lib/prisma';
+import { serializeBookSource } from '@/lib/serializers/book-source';
 import InvoiceCreateInput from '@/types/InvoiceCreateInput';
 import InvoiceHydrated from '@/types/InvoiceHydrated';
 import PageInfo from '@/types/PageInfo';
@@ -34,6 +35,7 @@ export async function createInvoice(
     ...createdInvoice,
     // when we create a new invoice, we have no invoice items, so this can be hardcoded
     numInvoiceItems: 0,
+    vendor: serializeBookSource(createdInvoice.vendor),
   };
 }
 
@@ -84,6 +86,7 @@ export async function completeInvoice(
     return {
       ...invoice,
       numInvoiceItems: invoice._count.invoiceItems,
+      vendor: serializeBookSource(invoice.vendor),
     };
   });
 }
@@ -115,6 +118,7 @@ export async function getInvoices({
   const items = rawItems.map((item) => ({
     ...item,
     numInvoiceItems: item._count.invoiceItems,
+    vendor: serializeBookSource(item.vendor),
   }));
 
   const { items: invoices, pageInfo } =
@@ -146,6 +150,7 @@ export async function getInvoice(
     return {
       ...invoice,
       numInvoiceItems: invoice._count.invoiceItems,
+      vendor: serializeBookSource(invoice.vendor),
     };
   } else {
     return null;

--- a/src/lib/serializers/book-source.test.ts
+++ b/src/lib/serializers/book-source.test.ts
@@ -1,0 +1,29 @@
+import { fakeVendor } from '@/lib/fakes/book-source';
+import { serializeBookSource } from '@/lib/serializers/book-source';
+import { BookSource, Prisma } from '@prisma/client';
+
+describe('book source serializer', () => {
+  it('should serialize correctly with a discount percentage', () => {
+    const vendor: BookSource = {
+      ...fakeVendor(),
+      discountPercentage: new Prisma.Decimal(0.68),
+    };
+
+    expect(serializeBookSource(vendor)).toEqual({
+      ...vendor,
+      discountPercentage: 0.68,
+    });
+  });
+
+  it('should serialize correctly with no discount percentage', () => {
+    const vendor: BookSource = {
+      ...fakeVendor(),
+      discountPercentage: null,
+    };
+
+    expect(serializeBookSource(vendor)).toEqual({
+      ...vendor,
+      discountPercentage: null,
+    });
+  });
+});

--- a/src/lib/serializers/book-source.ts
+++ b/src/lib/serializers/book-source.ts
@@ -1,0 +1,13 @@
+import BookSourceSerialized from '@/types/BookSourceSerialized';
+import { BookSource } from '@prisma/client';
+
+export function serializeBookSource(
+  bookSource: BookSource,
+): BookSourceSerialized {
+  const discountPercentage = bookSource.discountPercentage?.toNumber() || null;
+
+  return {
+    ...bookSource,
+    discountPercentage,
+  };
+}

--- a/src/types/BookSourceSerialized.ts
+++ b/src/types/BookSourceSerialized.ts
@@ -1,0 +1,7 @@
+import { BookSource } from '@prisma/client';
+
+type BookSourceSerialized = Omit<BookSource, 'discountPercentage'> & {
+  discountPercentage: number | null;
+};
+
+export default BookSourceSerialized;

--- a/src/types/InvoiceHydrated.ts
+++ b/src/types/InvoiceHydrated.ts
@@ -1,7 +1,8 @@
-import { BookSource, Invoice } from '@prisma/client';
+import BookSourceSerialized from '@/types/BookSourceSerialized';
+import { Invoice } from '@prisma/client';
 
 type InvoiceHydrated = Invoice & {
   numInvoiceItems: number;
-  vendor: BookSource;
+  vendor: BookSourceSerialized;
 };
 export default InvoiceHydrated;


### PR DESCRIPTION
- There are aspects of the BookSource (Vendor) that can not be serialized, which show up as warnings/errors in the UI. To solve this, we'll process the book source and make sure its only using plain types.
- Update the invoice actions to serialize the vendor