### PR TITLE
chore: book source vendor/publisher flags

### DIFF
--- a/src/app/add/VendorContainer.tsx
+++ b/src/app/add/VendorContainer.tsx
@@ -2,9 +2,9 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import VendorSelect from '@/components/book-source/VendorSelect';
-import { BookSource } from '@prisma/client';
 import { getBookSources } from '@/lib/actions/book-source';
 import { VendorCreateFormInput } from '@/components/book-source/VendorCreate';
+import BookSourceSerialized from '@/types/BookSourceSerialized';
 
 export default function VendorContainer({
   hasError,
@@ -13,10 +13,11 @@ export default function VendorContainer({
   hasError?: boolean;
   onSelect: (value: number) => void;
 }) {
-  const [vendors, setVendors] = useState<Array<BookSource>>([]);
+  const [vendors, setVendors] = useState<Array<BookSourceSerialized>>([]);
 
   const loadVendors = useCallback(async () => {
     const { bookSources: vendors } = await getBookSources({
+      isVendor: true,
       paginationQuery: {
         // TODO need to find a way to solve this
         first: 100,

--- a/src/app/api/book-sources/route.test.ts
+++ b/src/app/api/book-sources/route.test.ts
@@ -51,5 +51,41 @@ describe('/api/book-sources', () => {
         'Validation error: Expected number, received nan at "first"',
       );
     });
+
+    it('success with isPublisher parameter', async () => {
+      mockGetBookSources.mockReturnValue([]);
+
+      const req = new NextRequest(
+        new Request(buildBookSourcesUrl('isPublisher=true')),
+        {
+          method: 'GET',
+        },
+      );
+      const res = await GET(req);
+
+      expect(res.status).toEqual(200);
+      expect(mockGetBookSources).toHaveBeenCalledWith({
+        isPublisher: true,
+        paginationQuery: {},
+      });
+    });
+
+    it('success with isVendor parameter', async () => {
+      mockGetBookSources.mockReturnValue([]);
+
+      const req = new NextRequest(
+        new Request(buildBookSourcesUrl('isVendor=true')),
+        {
+          method: 'GET',
+        },
+      );
+      const res = await GET(req);
+
+      expect(res.status).toEqual(200);
+      expect(mockGetBookSources).toHaveBeenCalledWith({
+        isVendor: true,
+        paginationQuery: {},
+      });
+    });
   });
 });

--- a/src/app/api/book-sources/route.ts
+++ b/src/app/api/book-sources/route.ts
@@ -7,20 +7,16 @@ const schema = z.object({
   after: z.string().optional().nullable(),
   before: z.string().optional().nullable(),
   first: z.coerce.number().optional().nullable(),
+  isPublisher: z.coerce.boolean().optional(),
+  isVendor: z.coerce.boolean().optional(),
   last: z.coerce.number().optional().nullable(),
 });
 
 export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
   const params = Object.fromEntries(searchParams.entries());
-  const { after, before, first, last } = params;
 
-  const validatedFields = schema.safeParse({
-    after,
-    before,
-    first,
-    last,
-  });
+  const validatedFields = schema.safeParse(params);
 
   if (!validatedFields.success) {
     const message = fromZodError(validatedFields.error);
@@ -30,10 +26,13 @@ export async function GET(request: NextRequest) {
     });
   }
 
+  const { after, before, first, last } = validatedFields.data;
+  const { isPublisher, isVendor } = validatedFields.data;
+
   const response = await getBookSources({
-    paginationQuery: {
-      ...validatedFields.data,
-    },
+    isPublisher,
+    isVendor,
+    paginationQuery: { after, before, first, last },
   });
 
   return Response.json(response);

--- a/src/components/book-source/VendorSelect.tsx
+++ b/src/components/book-source/VendorSelect.tsx
@@ -8,7 +8,7 @@ import {
   SelectContent,
   SelectItem,
 } from '@/components/ui/select';
-import { BookSource } from '@prisma/client';
+import BookSourceSerialized from '@/types/BookSourceSerialized';
 import clsx from 'clsx';
 import _ from 'lodash';
 import { useCallback } from 'react';
@@ -25,7 +25,7 @@ export default function VendorSelect({
   onSelect: (value: number) => void;
   onVendorCreate?: SubmitHandler<VendorCreateFormInput>;
   selectedVendorId?: number;
-  vendors: Array<BookSource>;
+  vendors: Array<BookSourceSerialized>;
 }) {
   const onValueChange = useCallback(
     async (value: string) => {

--- a/src/components/invoice/InvoiceCreate.tsx
+++ b/src/components/invoice/InvoiceCreate.tsx
@@ -11,7 +11,7 @@ import {
   SheetTitle,
   SheetTrigger,
 } from '@/components/ui/sheet';
-import { BookSource } from '@prisma/client';
+import BookSourceSerialized from '@/types/BookSourceSerialized';
 import { useCallback, useState } from 'react';
 import { SubmitHandler, useForm } from 'react-hook-form';
 
@@ -26,7 +26,7 @@ export default function InvoiceCreate({
   vendors,
 }: {
   onCreate: SubmitHandler<InvoiceCreateFormInput>;
-  vendors: Array<BookSource>;
+  vendors: Array<BookSourceSerialized>;
 }) {
   const [isOpen, setIsOpen] = useState(false);
   const {

--- a/src/components/stories/book-source/VendorSelect.stories.tsx
+++ b/src/components/stories/book-source/VendorSelect.stories.tsx
@@ -1,5 +1,5 @@
 import VendorSelect from '@/components/book-source/VendorSelect';
-import { fakeVendor } from '@/lib/fakes/book-source';
+import { fakeVendorSerialized } from '@/lib/fakes/book-source';
 import type { Meta, StoryObj } from '@storybook/react';
 import _ from 'lodash';
 
@@ -10,7 +10,7 @@ const meta: Meta<typeof VendorSelect> = {
 export default meta;
 type Story = StoryObj<typeof VendorSelect>;
 
-const vendors = _.times(5, fakeVendor);
+const vendors = _.times(5, fakeVendorSerialized);
 
 export const Default: Story = {
   args: {

--- a/src/components/stories/invoice/InvoiceCreate.stories.tsx
+++ b/src/components/stories/invoice/InvoiceCreate.stories.tsx
@@ -1,5 +1,5 @@
 import InvoiceCreate from '@/components/invoice/InvoiceCreate';
-import { fakeVendor } from '@/lib/fakes/book-source';
+import { fakeVendorSerialized } from '@/lib/fakes/book-source';
 import { Meta, StoryObj } from '@storybook/react';
 import _ from 'lodash';
 
@@ -12,7 +12,7 @@ type Story = StoryObj<typeof InvoiceCreate>;
 
 export const Default: Story = {
   render: () => {
-    const vendors = _.times(3, fakeVendor);
+    const vendors = _.times(3, fakeVendorSerialized);
     return (
       <>
         <InvoiceCreate

--- a/src/lib/actions/book-source.test.ts
+++ b/src/lib/actions/book-source.test.ts
@@ -1,6 +1,11 @@
 import { getBookSources } from '@/lib/actions/book-source';
 import { prismaMock } from '../../../test-setup/prisma-mock.setup';
 import { fakePublisher, fakeVendor } from '@/lib/fakes/book-source';
+import { buildPaginationRequest } from '@/lib/pagination';
+
+jest.mock('../serializers/book-source', () => ({
+  serializeBookSource: (vendor: unknown) => vendor,
+}));
 
 describe('book-source actions', () => {
   const bookSource1 = fakeVendor();
@@ -49,6 +54,28 @@ describe('book-source actions', () => {
           hasPreviousPage: true,
           startCursor: bookSource2.id.toString(),
         },
+      });
+    });
+
+    it('should send correct input when provided with isPublisher', async () => {
+      prismaMock.bookSource.findMany.mockResolvedValue([]);
+
+      await getBookSources({ isPublisher: true });
+
+      expect(prismaMock.bookSource.findMany).toHaveBeenCalledWith({
+        ...buildPaginationRequest({}),
+        where: { isPublisher: true },
+      });
+    });
+
+    it('should send correct input when provided with isVendor', async () => {
+      prismaMock.bookSource.findMany.mockResolvedValue([]);
+
+      await getBookSources({ isVendor: true });
+
+      expect(prismaMock.bookSource.findMany).toHaveBeenCalledWith({
+        ...buildPaginationRequest({}),
+        where: { isVendor: true },
       });
     });
   });

--- a/src/lib/actions/book-source.ts
+++ b/src/lib/actions/book-source.ts
@@ -5,32 +5,41 @@ import {
   buildPaginationResponse,
 } from '@/lib/pagination';
 import prisma from '@/lib/prisma';
+import { serializeBookSource } from '@/lib/serializers/book-source';
+import BookSourceSerialized from '@/types/BookSourceSerialized';
 import PageInfo from '@/types/PageInfo';
 import PaginationQuery from '@/types/PaginationQuery';
-import { BookSource } from '@prisma/client';
 
 export type GetBookSourcesParams = {
+  isPublisher?: boolean;
+  isVendor?: boolean;
   paginationQuery?: PaginationQuery;
 };
 
 export type GetBookSourcesResult = {
-  bookSources: Array<BookSource>;
+  bookSources: Array<BookSourceSerialized>;
   pageInfo: PageInfo;
 };
 
 export async function getBookSources({
+  isPublisher,
+  isVendor,
   paginationQuery,
 }: GetBookSourcesParams): Promise<GetBookSourcesResult> {
   const paginationRequest = buildPaginationRequest({ paginationQuery });
 
-  const items = await prisma.bookSource.findMany({
+  const rawItems = await prisma.bookSource.findMany({
     ...paginationRequest,
+    where: { isPublisher, isVendor },
   });
 
-  const { items: bookSources, pageInfo } = buildPaginationResponse<BookSource>({
-    items,
-    paginationQuery,
-  });
+  const items = rawItems.map(serializeBookSource);
+
+  const { items: bookSources, pageInfo } =
+    buildPaginationResponse<BookSourceSerialized>({
+      items,
+      paginationQuery,
+    });
 
   return {
     bookSources,

--- a/src/lib/fakes/book-source.ts
+++ b/src/lib/fakes/book-source.ts
@@ -1,4 +1,6 @@
 import { fakeCreatedAtUpdatedAt } from '@/lib/fakes/created-at-updated-at';
+import { serializeBookSource } from '@/lib/serializers/book-source';
+import BookSourceSerialized from '@/types/BookSourceSerialized';
 import { faker } from '@faker-js/faker';
 import { BookSource, Prisma } from '@prisma/client';
 
@@ -29,4 +31,8 @@ export function fakeVendor(): BookSource {
     isVendor: true,
     name: faker.company.name(),
   };
+}
+
+export function fakeVendorSerialized(): BookSourceSerialized {
+  return serializeBookSource(fakeVendor());
 }


### PR DESCRIPTION
The isPublisher and isVendor flags were not available as selectors to the actions or API. Fix this.

And in testing, found that the book source was going out un-serialized, so need to change that (and then a ton of files that reference BookSource).