### PR TITLE
feat: getInvoiceItems

### DIFF
--- a/src/lib/actions/invoice-item.test.ts
+++ b/src/lib/actions/invoice-item.test.ts
@@ -1,10 +1,11 @@
 import { prismaMock } from '../../../test-setup/prisma-mock.setup';
-import { createInvoiceItem } from '@/lib/actions/invoice-item';
+import { createInvoiceItem, getInvoiceItems } from '@/lib/actions/invoice-item';
 import { fakeBook } from '@/lib/fakes/book';
 import {
   fakeInvoiceItem,
   fakeInvoiceItemHydrated,
 } from '@/lib/fakes/invoice-item';
+import { buildPaginationRequest } from '@/lib/pagination';
 
 const mockUpsertBook = jest.fn();
 jest.mock('./book', () => ({
@@ -13,8 +14,10 @@ jest.mock('./book', () => ({
 
 describe('invoice-item actions', () => {
   const book = fakeBook();
-  const invoiceItem = fakeInvoiceItem();
-  const invoiceItemHydrated = fakeInvoiceItemHydrated();
+  const invoiceItem1 = fakeInvoiceItem();
+  const invoiceItemHydrated1 = fakeInvoiceItemHydrated();
+  const invoiceItemHydrated2 = fakeInvoiceItemHydrated();
+  const invoiceItemHydrated3 = fakeInvoiceItemHydrated();
   beforeEach(() => {
     mockUpsertBook.mockReset();
   });
@@ -25,7 +28,7 @@ describe('invoice-item actions', () => {
     });
 
     it('should create a new invoice item', async () => {
-      prismaMock.invoiceItem.create.mockResolvedValue(invoiceItemHydrated);
+      prismaMock.invoiceItem.create.mockResolvedValue(invoiceItemHydrated1);
 
       const result = await createInvoiceItem({
         book: {
@@ -33,7 +36,7 @@ describe('invoice-item actions', () => {
           authors: 'author1',
           publisher: 'publisher2',
         },
-        ...invoiceItem,
+        ...invoiceItem1,
       });
 
       expect(prismaMock.invoiceItem.create).toHaveBeenCalledWith({
@@ -42,11 +45,11 @@ describe('invoice-item actions', () => {
             connect: { id: book.id },
           },
           invoice: {
-            connect: { id: invoiceItem.invoiceId },
+            connect: { id: invoiceItem1.invoiceId },
           },
-          itemCostInCents: invoiceItem.itemCostInCents,
-          quantity: invoiceItem.quantity,
-          totalCostInCents: invoiceItem.totalCostInCents,
+          itemCostInCents: invoiceItem1.itemCostInCents,
+          quantity: invoiceItem1.quantity,
+          totalCostInCents: invoiceItem1.totalCostInCents,
         },
         include: {
           book: {
@@ -55,11 +58,91 @@ describe('invoice-item actions', () => {
               publisher: true,
             },
           },
-          invoice: true,
         },
       });
 
-      expect(result).toEqual(invoiceItemHydrated);
+      expect(result).toEqual(invoiceItemHydrated1);
+    });
+  });
+
+  describe('getInvoiceItems', () => {
+    it('should get invoice items when provided with default input', async () => {
+      prismaMock.invoiceItem.findMany.mockResolvedValue([
+        invoiceItemHydrated1,
+        invoiceItemHydrated2,
+        invoiceItemHydrated3,
+      ]);
+
+      const result = await getInvoiceItems({});
+
+      expect(prismaMock.invoiceItem.findMany).toHaveBeenCalledWith({
+        ...buildPaginationRequest({}),
+        include: {
+          book: {
+            include: {
+              authors: true,
+              publisher: true,
+            },
+          },
+        },
+        where: {},
+      });
+      expect(result).toEqual({
+        invoiceItems: [
+          invoiceItemHydrated1,
+          invoiceItemHydrated2,
+          invoiceItemHydrated3,
+        ],
+        pageInfo: {
+          endCursor: invoiceItemHydrated3.id.toString(),
+          hasNextPage: false,
+          hasPreviousPage: false,
+          startCursor: invoiceItemHydrated1.id.toString(),
+        },
+      });
+    });
+
+    it('should get invoices when provided with pagination query input', async () => {
+      prismaMock.invoiceItem.findMany.mockResolvedValue([
+        invoiceItemHydrated2,
+        invoiceItemHydrated3,
+      ]);
+
+      const result = await getInvoiceItems({
+        paginationQuery: {
+          after: '1',
+          first: 2,
+        },
+      });
+
+      expect(result).toEqual({
+        invoiceItems: [invoiceItemHydrated2, invoiceItemHydrated3],
+        pageInfo: {
+          endCursor: invoiceItemHydrated3.id.toString(),
+          hasNextPage: false,
+          hasPreviousPage: true,
+          startCursor: invoiceItemHydrated2.id.toString(),
+        },
+      });
+    });
+
+    it('should pass correct values to prisma when provided with invoiceId', async () => {
+      prismaMock.invoiceItem.findMany.mockResolvedValue([]);
+
+      await getInvoiceItems({ invoiceId: 123 });
+
+      expect(prismaMock.invoiceItem.findMany).toHaveBeenCalledWith({
+        ...buildPaginationRequest({}),
+        include: {
+          book: {
+            include: {
+              authors: true,
+              publisher: true,
+            },
+          },
+        },
+        where: { invoiceId: 123 },
+      });
     });
   });
 });

--- a/src/lib/actions/invoice-item.ts
+++ b/src/lib/actions/invoice-item.ts
@@ -1,9 +1,15 @@
 import { upsertBook } from '@/lib/actions/book';
 import logger from '@/lib/logger';
+import {
+  buildPaginationRequest,
+  buildPaginationResponse,
+} from '@/lib/pagination';
 import prisma from '@/lib/prisma';
 import { serializeBookSource } from '@/lib/serializers/book-source';
 import InvoiceItemCreateInput from '@/types/InvoiceItemCreateInput';
 import InvoiceItemHydrated from '@/types/InvoiceItemHydrated';
+import PageInfo from '@/types/PageInfo';
+import PaginationQuery from '@/types/PaginationQuery';
 
 export async function createInvoiceItem(
   invoiceItem: InvoiceItemCreateInput,
@@ -37,7 +43,6 @@ export async function createInvoiceItem(
           publisher: true,
         },
       },
-      invoice: true,
     },
   });
 
@@ -52,4 +57,53 @@ export async function createInvoiceItem(
   logger.trace('created invoice item in DB: %j', invoiceItemCreated);
 
   return invoiceItemCreated;
+}
+
+export interface GetInvoiceItemsParams {
+  paginationQuery?: PaginationQuery;
+  invoiceId?: number;
+}
+
+export interface GetInvoiceItemsResult {
+  invoiceItems: Array<InvoiceItemHydrated>;
+  pageInfo: PageInfo;
+}
+
+export async function getInvoiceItems({
+  paginationQuery,
+  invoiceId,
+}: GetInvoiceItemsParams): Promise<GetInvoiceItemsResult> {
+  const paginationRequest = buildPaginationRequest({ paginationQuery });
+
+  const rawItems = await prisma.invoiceItem.findMany({
+    ...paginationRequest,
+    include: {
+      book: {
+        include: {
+          authors: true,
+          publisher: true,
+        },
+      },
+    },
+    where: { invoiceId },
+  });
+
+  const items = rawItems.map((item) => ({
+    ...item,
+    book: {
+      ...item.book,
+      publisher: serializeBookSource(item.book.publisher),
+    },
+  }));
+
+  const { items: invoiceItems, pageInfo } =
+    buildPaginationResponse<InvoiceItemHydrated>({
+      items,
+      paginationQuery,
+    });
+
+  return {
+    invoiceItems,
+    pageInfo,
+  };
 }

--- a/src/lib/fakes/invoice-item.ts
+++ b/src/lib/fakes/invoice-item.ts
@@ -1,6 +1,5 @@
 import { fakeBookHydrated } from '@/lib/fakes/book';
 import { fakeCreatedAtUpdatedAt } from '@/lib/fakes/created-at-updated-at';
-import { fakeInvoice } from '@/lib/fakes/invoice';
 import InvoiceItemHydrated from '@/types/InvoiceItemHydrated';
 import { faker } from '@faker-js/faker';
 import { InvoiceItem } from '@prisma/client';
@@ -26,11 +25,9 @@ export function fakeInvoiceItem(): InvoiceItem {
 export function fakeInvoiceItemHydrated(): InvoiceItemHydrated {
   const invoiceItem = fakeInvoiceItem();
   const book = fakeBookHydrated();
-  const invoice = fakeInvoice();
 
   return {
     ...invoiceItem,
     book,
-    invoice,
   };
 }

--- a/src/types/InvoiceItemHydrated.ts
+++ b/src/types/InvoiceItemHydrated.ts
@@ -1,8 +1,7 @@
 import BookHydrated from '@/types/BookHydrated';
-import { Invoice, InvoiceItem } from '@prisma/client';
+import { InvoiceItem } from '@prisma/client';
 
 type InvoiceItemHydrated = InvoiceItem & {
   book: BookHydrated;
-  invoice: Invoice;
 };
 export default InvoiceItemHydrated;


### PR DESCRIPTION
- Add action to get the invoice items, with an optional parameter to narrow down by invoice ID
- in testing, it wasn't necessary to load the Invoice in the response, so remove that from the InvoiceItemHydrated