### PR TITLE
chore: refactor out google book search

### DIFF
--- a/src/lib/search/external/useExternalBookSearch.ts
+++ b/src/lib/search/external/useExternalBookSearch.ts
@@ -1,99 +1,14 @@
-import logger from '@/lib/logger';
-
-export type ExternalBookSearchInput = {
-  isbn: string;
-};
-
-export type ExternalBookSearchResult = {
-  authorsHint?: string;
-  genresHint?: string;
-  imageUrl?: string;
-  isbn13?: string;
-  publishedDate?: Date;
-  publisherHint?: string;
-  title?: string;
-};
-
-export interface GoogleSearchResponse {
-  totalItems: number;
-  items: Array<{
-    volumeInfo: {
-      authors?: [string];
-      categories?: [string];
-      imageLinks?: {
-        thumbnail?: string;
-      };
-      industryIdentifiers: Array<{
-        identifier: string;
-        type: string;
-      }>;
-      publishedDate?: Date;
-      publisher: string;
-      title: string;
-    };
-  }>;
-}
-
-function buildGoogleSearchUrl(ISBN: string) {
-  return `https://www.googleapis.com/books/v1/volumes?q=isbn:${ISBN}`;
-}
-
-async function googleBookSearch(
-  input: ExternalBookSearchInput,
-): Promise<ExternalBookSearchResult | null> {
-  // TODO do we need to care about other search input?
-  const searchUrl = buildGoogleSearchUrl(input.isbn);
-
-  const response = await fetch(searchUrl);
-  const data: GoogleSearchResponse = await response.json();
-  logger.trace('data returned from Google search %j', data);
-
-  if (data.totalItems > 0) {
-    // assume there is only 1 item in the response, since we searched by ISBN
-    // which should be unique
-    const item = data.items[0];
-    logger.trace('data returned item %j', item);
-
-    const {
-      volumeInfo: {
-        authors,
-        categories,
-        imageLinks,
-        industryIdentifiers,
-        publishedDate: publishedDateString,
-        publisher,
-        title,
-      },
-    } = item;
-
-    const book: ExternalBookSearchResult = {
-      authorsHint: authors?.join(', '),
-      genresHint: categories?.join(', '),
-      imageUrl: imageLinks?.thumbnail?.replaceAll('http://', 'https://'),
-      isbn13: industryIdentifiers.find((i) => i.type === 'ISBN_13')?.identifier,
-      publishedDate: publishedDateString
-        ? new Date(publishedDateString)
-        : undefined,
-      publisherHint: publisher,
-      title,
-    };
-    logger.trace('returning book %j', book);
-
-    return book;
-  } else {
-    logger.trace('no data found, returning null');
-    return null;
-  }
-}
+import { GoogleBookSearchInput, googleBookSearch } from '@/lib/search/google';
+import BookFormInput from '@/types/BookFormInput';
 
 export type UseExternalBookSearchResult = (
-  input: ExternalBookSearchInput,
-) => Promise<ExternalBookSearchResult | null>;
+  input: GoogleBookSearchInput,
+) => Promise<Partial<BookFormInput>>;
 
 export default function useExternalBookSearch(): UseExternalBookSearchResult {
   const search = async (
-    input: ExternalBookSearchInput,
-  ): Promise<ExternalBookSearchResult | null> => {
+    input: GoogleBookSearchInput,
+  ): Promise<Partial<BookFormInput>> => {
     // currently only support Google as a search mechanism
     return googleBookSearch(input);
   };

--- a/src/lib/search/google.ts
+++ b/src/lib/search/google.ts
@@ -1,0 +1,81 @@
+'use server';
+
+import logger from '@/lib/logger';
+import BookFormInput from '@/types/BookFormInput';
+
+export type GoogleBookSearchInput = {
+  isbn13: string;
+};
+
+export interface GoogleSearchResponse {
+  totalItems: number;
+  items: Array<{
+    volumeInfo: {
+      authors?: [string];
+      categories?: [string];
+      imageLinks?: {
+        thumbnail?: string;
+      };
+      industryIdentifiers: Array<{
+        identifier: string;
+        type: string;
+      }>;
+      publishedDate?: string;
+      publisher: string;
+      title: string;
+    };
+  }>;
+}
+
+function buildGoogleSearchUrl(ISBN: string) {
+  return `https://www.googleapis.com/books/v1/volumes?q=isbn:${ISBN}`;
+}
+
+export async function googleBookSearch(
+  input: GoogleBookSearchInput,
+): Promise<Partial<BookFormInput>> {
+  const { isbn13 } = input;
+  const searchUrl = buildGoogleSearchUrl(isbn13);
+
+  const response = await fetch(searchUrl);
+  const data: GoogleSearchResponse = await response.json();
+  logger.trace('data returned from Google search %j', data);
+
+  if (data.totalItems > 0) {
+    // assume there is only 1 item in the response, since we searched by ISBN
+    // which should be unique
+    const item = data.items[0];
+    logger.trace('data returned item %j', item);
+
+    const {
+      volumeInfo: {
+        authors,
+        categories,
+        imageLinks,
+        publishedDate,
+        publisher,
+        title,
+      },
+    } = item;
+
+    // TODO map Google genres to our genres
+    const genre = categories?.[0];
+    logger.trace('google genre returned: %s', genre);
+
+    const book: Partial<BookFormInput> = {
+      authors: authors?.join(', '),
+      genre,
+      imageUrl: imageLinks?.thumbnail?.replaceAll('http://', 'https://'),
+      isbn13,
+      publishedDate,
+      publisher,
+      title,
+    };
+    logger.trace('returning book %j', book);
+
+    return book;
+  } else {
+    logger.trace('no data found');
+    return {};
+  }
+}

--- a/src/types/BookFormInput.ts
+++ b/src/types/BookFormInput.ts
@@ -1,0 +1,13 @@
+import BookCreateInput from '@/types/BookCreateInput';
+
+type BookFormInput = Omit<
+  BookCreateInput,
+  'format' | 'genre' | 'isbn13' | 'publishedDate'
+> & {
+  format: string;
+  genre: string;
+  isbn13: string;
+  publishedDate: string;
+};
+
+export default BookFormInput;


### PR DESCRIPTION
- Move the google book search code to its own library file within search.
- Create a new type BookFormInput which represents the form filled out to create/update a book. This basically just makes all the fields strings.
- Use this new type in the google book search and the add book page.