### PR TITLE
fix: fixes for invoice flow

### DIFF
--- a/src/app/invoices/[id]/page.tsx
+++ b/src/app/invoices/[id]/page.tsx
@@ -12,7 +12,7 @@ import { Button } from '@/components/ui/button';
 import { LoadingSpinner } from '@/components/ui/loading-spinner';
 import { completeInvoice, getInvoice } from '@/lib/actions/invoice';
 import { getInvoiceItems } from '@/lib/actions/invoice-item';
-import { DEFAULT_LIMIT } from '@/lib/pagination';
+import { discountPercentageToDisplayString } from '@/lib/money';
 import InvoiceHydrated from '@/types/InvoiceHydrated';
 import InvoiceItemHydrated from '@/types/InvoiceItemHydrated';
 import _ from 'lodash';
@@ -33,9 +33,7 @@ function InvoiceDescription({ invoice }: { invoice: InvoiceHydrated }) {
           <div className="text-right">
             <div>{vendor.accountNumber}</div>
             <div>
-              {vendor.discountPercentage
-                ? `${vendor.discountPercentage * 100}%`
-                : ''}
+              {discountPercentageToDisplayString(vendor.discountPercentage)}
             </div>
           </div>
         </div>
@@ -89,7 +87,7 @@ export default function InvoicePage({ params }: { params: { id: string } }) {
     const { invoiceItems } = await getInvoiceItems({
       invoiceId,
       paginationQuery: {
-        first: DEFAULT_LIMIT,
+        first: 100,
       },
     });
     setInvoiceItems(invoiceItems);

--- a/src/app/invoices/page.tsx
+++ b/src/app/invoices/page.tsx
@@ -10,7 +10,6 @@ import InvoiceCreate from '@/components/invoice/InvoiceCreate';
 import InvoicesTable from '@/components/invoice/InvoicesTable';
 import { getBookSources } from '@/lib/actions/book-source';
 import { createInvoice, getInvoices } from '@/lib/actions/invoice';
-import { DEFAULT_LIMIT } from '@/lib/pagination';
 import BookSourceSerialized from '@/types/BookSourceSerialized';
 import InvoiceHydrated from '@/types/InvoiceHydrated';
 import { usePathname, useRouter } from 'next/navigation';
@@ -28,7 +27,7 @@ export default function InvoicesPage() {
     const { bookSources: vendors } = await getBookSources({
       isVendor: true,
       paginationQuery: {
-        first: DEFAULT_LIMIT,
+        first: 100,
       },
     });
     setVendors(vendors);
@@ -48,7 +47,7 @@ export default function InvoicesPage() {
     // TODO handle pagination
     const { invoices } = await getInvoices({
       paginationQuery: {
-        first: DEFAULT_LIMIT,
+        first: 100,
       },
     });
     setInvoices(invoices);

--- a/src/lib/actions/invoice.ts
+++ b/src/lib/actions/invoice.ts
@@ -11,7 +11,7 @@ import InvoiceCreateInput from '@/types/InvoiceCreateInput';
 import InvoiceHydrated from '@/types/InvoiceHydrated';
 import PageInfo from '@/types/PageInfo';
 import PaginationQuery from '@/types/PaginationQuery';
-import { Invoice, InvoiceItem, Prisma } from '@prisma/client';
+import { Invoice, Prisma } from '@prisma/client';
 
 export async function createInvoice(
   invoice: InvoiceCreateInput,
@@ -41,16 +41,17 @@ export async function createInvoice(
 
 async function updateBookQuantity(
   tx: Prisma.TransactionClient,
-  invoiceItem: InvoiceItem,
+  bookId: number,
+  increasedQuantity: number,
 ): Promise<void> {
-  const { bookId, quantity } = invoiceItem;
-
   const book = await tx.book.findUniqueOrThrow({
     where: { id: bookId },
   });
 
+  const updatedQuantity = book.quantity + increasedQuantity;
+
   await tx.book.update({
-    data: { quantity: book.quantity + quantity },
+    data: { quantity: updatedQuantity },
     where: { id: bookId },
   });
 }
@@ -64,31 +65,60 @@ export async function completeInvoice(
     },
   });
 
-  return prisma.$transaction(async (tx) => {
-    logger.trace('updating books for %d invoice items...', invoiceItems.length);
-    await Promise.all(invoiceItems.map((item) => updateBookQuantity(tx, item)));
+  // condense all the book updates by book ID
+  const bookUpdates = invoiceItems.reduce(
+    (acc, item) => {
+      const match = acc.find((i) => i.id === item.bookId);
+      if (match) {
+        match.increasedQuantity += item.quantity;
+      } else {
+        acc.push({
+          id: item.bookId,
+          increasedQuantity: item.quantity,
+        });
+      }
+      return acc;
+    },
+    [] as Array<{ id: number; increasedQuantity: number }>,
+  );
 
-    logger.trace('marking invoice complete, invoice id: %s', invoiceId);
-    const invoice = await tx.invoice.update({
-      data: {
-        dateReceived: new Date(),
-        isCompleted: true,
-      },
-      include: {
-        _count: {
-          select: { invoiceItems: true },
+  return prisma.$transaction(
+    async (tx) => {
+      logger.trace(
+        'updating books for %d invoice items...',
+        invoiceItems.length,
+      );
+      await Promise.all(
+        bookUpdates.map((update) =>
+          updateBookQuantity(tx, update.id, update.increasedQuantity),
+        ),
+      );
+
+      logger.trace('marking invoice complete, invoice id: %s', invoiceId);
+      const invoice = await tx.invoice.update({
+        data: {
+          dateReceived: new Date(),
+          isCompleted: true,
         },
-        vendor: true,
-      },
-      where: { id: invoiceId },
-    });
+        include: {
+          _count: {
+            select: { invoiceItems: true },
+          },
+          vendor: true,
+        },
+        where: { id: invoiceId },
+      });
 
-    return {
-      ...invoice,
-      numInvoiceItems: invoice._count.invoiceItems,
-      vendor: serializeBookSource(invoice.vendor),
-    };
-  });
+      return {
+        ...invoice,
+        numInvoiceItems: invoice._count.invoiceItems,
+        vendor: serializeBookSource(invoice.vendor),
+      };
+    },
+    {
+      isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+    },
+  );
 }
 
 export interface GetInvoicesParams {

--- a/src/lib/money.test.ts
+++ b/src/lib/money.test.ts
@@ -1,5 +1,6 @@
 import {
   convertCentsToDollars,
+  discountPercentageToDisplayString,
   convertDollarsToCents,
   determineDiscountedAmountInCents,
 } from '@/lib/money';
@@ -51,6 +52,24 @@ describe('money', () => {
           priceInCents: 2000,
         }),
       ).toEqual(0);
+    });
+  });
+
+  describe('discountPercentageToDisplayString', () => {
+    it('should work with a simple number', () => {
+      expect(discountPercentageToDisplayString(0.56)).toEqual('56%');
+    });
+
+    it('should work with a complex number', () => {
+      expect(discountPercentageToDisplayString(0.56348)).toEqual('56.35%');
+    });
+
+    it('should work with 0', () => {
+      expect(discountPercentageToDisplayString(0)).toEqual('0%');
+    });
+
+    it('should work with null', () => {
+      expect(discountPercentageToDisplayString(null)).toEqual('0%');
     });
   });
 });

--- a/src/lib/money.ts
+++ b/src/lib/money.ts
@@ -18,3 +18,9 @@ export function determineDiscountedAmountInCents({
   const cost = priceInCents - priceInCents * discountPercentage;
   return cost;
 }
+
+export function discountPercentageToDisplayString(
+  discountPercentage: number | null,
+): string {
+  return `${_.round((discountPercentage ?? 0) * 100, 2)}%`;
+}


### PR DESCRIPTION
There was a bug in the invoice completion flow, where we were writing updates for the same book independently within the transaction. So if the same book was in the list more than once, they would all use the same original value for quantity. This fix combines the same books to a single update to fix this issue.

Additional fixes found during testing:
- since we're not using pagination in the UI, increase the limit to 100 until we do
- correctly show the discount percentage string, adding a function in money