### PR TITLE
feat: invoice action tweaks

### DIFF
--- a/src/lib/actions/invoice-item.test.ts
+++ b/src/lib/actions/invoice-item.test.ts
@@ -85,6 +85,7 @@ describe('invoice-item actions', () => {
             },
           },
         },
+        orderBy: { createdAt: 'desc' },
         where: {},
       });
       expect(result).toEqual({
@@ -141,6 +142,7 @@ describe('invoice-item actions', () => {
             },
           },
         },
+        orderBy: { createdAt: 'desc' },
         where: { invoiceId: 123 },
       });
     });

--- a/src/lib/actions/invoice-item.ts
+++ b/src/lib/actions/invoice-item.ts
@@ -87,6 +87,7 @@ export async function getInvoiceItems({
         },
       },
     },
+    orderBy: { createdAt: 'desc' },
     where: { invoiceId },
   });
 

--- a/src/lib/actions/invoice.test.ts
+++ b/src/lib/actions/invoice.test.ts
@@ -9,6 +9,7 @@ import {
 import { fakeInvoiceItem } from '@/lib/fakes/invoice-item';
 import { fakeBook } from '@/lib/fakes/book';
 import { Invoice } from '@prisma/client';
+import { buildPaginationRequest } from '@/lib/pagination';
 
 jest.mock('../serializers/book-source', () => ({
   serializeBookSource: (vendor: unknown) => vendor,
@@ -141,6 +142,16 @@ describe('invoice actions', () => {
 
       const result = await getInvoices({});
 
+      expect(prismaMock.invoice.findMany).toHaveBeenCalledWith({
+        ...buildPaginationRequest({}),
+        include: {
+          _count: {
+            select: { invoiceItems: true },
+          },
+          vendor: true,
+        },
+        orderBy: { createdAt: 'desc' },
+      });
       expect(result).toEqual({
         invoices: [
           {

--- a/src/lib/actions/invoice.ts
+++ b/src/lib/actions/invoice.ts
@@ -48,8 +48,14 @@ async function updateBookQuantity(
     where: { id: bookId },
   });
 
+  logger.trace(
+    'book.quantity: %d increasedQuantity: %d',
+    book.quantity,
+    increasedQuantity,
+  );
   const updatedQuantity = book.quantity + increasedQuantity;
 
+  logger.trace('updating book id: %s to quantity: %d', bookId, updatedQuantity);
   await tx.book.update({
     data: { quantity: updatedQuantity },
     where: { id: bookId },
@@ -143,6 +149,7 @@ export async function getInvoices({
       },
       vendor: true,
     },
+    orderBy: { createdAt: 'desc' },
   });
 
   const items = rawItems.map((item) => ({

--- a/src/lib/search/google.test.ts
+++ b/src/lib/search/google.test.ts
@@ -120,9 +120,9 @@ describe('google search', () => {
       afterEach(() => server.resetHandlers());
       afterAll(() => server.close());
 
-      it('should return empty book', async () => {
+      it('should return book with just input isbn', async () => {
         const result = await googleBookSearch({ isbn13 });
-        expect(result).toEqual({});
+        expect(result).toEqual({ isbn13 });
       });
     });
   });

--- a/src/lib/search/google.ts
+++ b/src/lib/search/google.ts
@@ -75,7 +75,9 @@ export async function googleBookSearch(
 
     return book;
   } else {
-    logger.trace('no data found');
-    return {};
+    logger.trace('no data found, returning only input ISBN number');
+    return {
+      isbn13,
+    };
   }
 }


### PR DESCRIPTION
- for both invoice and invoice items, return the list of entities in descending order by createdAt date. This will show the most recent entry _first_ in the list, as the user requested.
- when searching for books via google, in the case no book is found we can still return the isbn number to display rather than nothing.