### PR TITLE
feat: search internally for book in invoice

### DIFF
--- a/src/lib/fakes/book-source.ts
+++ b/src/lib/fakes/book-source.ts
@@ -16,6 +16,10 @@ export function fakePublisher(): BookSource {
   };
 }
 
+export function fakePublisherSerialized(): BookSourceSerialized {
+  return serializeBookSource(fakePublisher());
+}
+
 export function fakeVendor(): BookSource {
   // some vendors can also be publishers, so randomly assign isPublisher
   const isPublisher = faker.datatype.boolean();

--- a/src/lib/search/book.test.ts
+++ b/src/lib/search/book.test.ts
@@ -1,0 +1,57 @@
+import { findBookByIsbn13 } from '@/lib/search/book';
+
+const mockGetBook = jest.fn();
+jest.mock('../actions/book', () => ({
+  getBook: (...args: unknown[]) => mockGetBook(...args),
+}));
+
+const mockTransformBookHydratedToBookFormInput = jest.fn();
+jest.mock('../transformers/book', () => ({
+  transformBookHydratedToBookFormInput: (...args: unknown[]) =>
+    mockTransformBookHydratedToBookFormInput(...args),
+}));
+
+const mockGoogleBookSearch = jest.fn();
+jest.mock('./google', () => ({
+  googleBookSearch: (...args: unknown[]) => mockGoogleBookSearch(...args),
+}));
+
+describe('book search', () => {
+  beforeEach(() => {
+    mockGetBook.mockReset();
+    mockTransformBookHydratedToBookFormInput.mockReset();
+  });
+
+  describe('findBookByIsbn13', () => {
+    it('should return hydrated book when found', async () => {
+      mockGetBook.mockReturnValue('book');
+      mockTransformBookHydratedToBookFormInput.mockReturnValue(
+        'transformed book',
+      );
+
+      const result = await findBookByIsbn13({
+        isbn13: '123',
+        timezone: 'zone',
+      });
+      expect(mockTransformBookHydratedToBookFormInput).toHaveBeenCalledWith(
+        'book',
+        'zone',
+      );
+      expect(mockGoogleBookSearch).not.toHaveBeenCalled();
+      expect(result).toEqual('transformed book');
+    });
+
+    it('should return google search book when no internal book found', async () => {
+      mockGetBook.mockReturnValue(null);
+      mockGoogleBookSearch.mockReturnValue('google search book');
+
+      const result = await findBookByIsbn13({
+        isbn13: '123',
+        timezone: 'zone',
+      });
+      expect(mockTransformBookHydratedToBookFormInput).not.toHaveBeenCalled();
+      expect(mockGoogleBookSearch).toHaveBeenCalledWith({ isbn13: '123' });
+      expect(result).toEqual('google search book');
+    });
+  });
+});

--- a/src/lib/search/book.ts
+++ b/src/lib/search/book.ts
@@ -1,0 +1,32 @@
+'use server';
+
+import { getBook } from '@/lib/actions/book';
+import logger from '@/lib/logger';
+import { googleBookSearch } from '@/lib/search/google';
+import { transformBookHydratedToBookFormInput } from '@/lib/transformers/book';
+import BookFormInput from '@/types/BookFormInput';
+
+/**
+ * Searches to find a Book first internally, and if not found, then externally.
+ */
+export async function findBookByIsbn13({
+  isbn13,
+  timezone,
+}: {
+  isbn13: string;
+  timezone: string;
+}): Promise<Partial<BookFormInput>> {
+  const bookHydrated = await getBook(BigInt(isbn13));
+  if (bookHydrated) {
+    logger.trace('book found internally, with ID: %s', bookHydrated.id);
+    const bookFormInput = transformBookHydratedToBookFormInput(
+      bookHydrated,
+      timezone,
+    );
+    logger.trace('returning book %j', bookFormInput);
+    return bookFormInput;
+  }
+
+  logger.trace('book not found internally, using google search...');
+  return googleBookSearch({ isbn13 });
+}

--- a/src/lib/transformers/book.test.ts
+++ b/src/lib/transformers/book.test.ts
@@ -1,0 +1,67 @@
+import { fakeAuthor } from '@/lib/fakes/author';
+import { fakePublisherSerialized } from '@/lib/fakes/book-source';
+import { fakeCreatedAtUpdatedAt } from '@/lib/fakes/created-at-updated-at';
+import { transformBookHydratedToBookFormInput } from '@/lib/transformers/book';
+import BookFormInput from '@/types/BookFormInput';
+import BookHydrated from '@/types/BookHydrated';
+import { Format, Genre } from '@prisma/client';
+
+describe('book transformers', () => {
+  describe('transformBookHydratedToBookFormInput', () => {
+    const date = new Date('2000-01-02T06:00:00.000Z');
+    const bookHydrated: BookHydrated = {
+      ...fakeCreatedAtUpdatedAt(),
+      authors: [
+        { ...fakeAuthor(), name: 'Author 1' },
+        { ...fakeAuthor(), name: 'Author 2' },
+      ],
+      format: Format.TRADE_PAPERBACK,
+      genre: Genre.FANTASY,
+      id: 123,
+      imageUrl: 'http://image.com',
+      isbn13: BigInt('987'),
+      priceInCents: 1999,
+      publishedDate: date,
+      publisher: {
+        ...fakePublisherSerialized(),
+        name: 'Publisher 1',
+      },
+      publisherId: 1,
+      quantity: 12,
+      title: 'My Book',
+    };
+    const bookFormInput: BookFormInput = {
+      authors: 'Author 1, Author 2',
+      format: 'TRADE_PAPERBACK',
+      genre: 'FANTASY',
+      imageUrl: 'http://image.com',
+      isbn13: '987',
+      priceInCents: '19.99',
+      publishedDate: '2000-01-02',
+      publisher: 'Publisher 1',
+      quantity: '12',
+      title: 'My Book',
+    };
+
+    it('should work with a fully populated book', () => {
+      expect(
+        transformBookHydratedToBookFormInput(bookHydrated, 'America/Chicago'),
+      ).toEqual(bookFormInput);
+    });
+
+    it('should work with a book without optional fields', () => {
+      expect(
+        transformBookHydratedToBookFormInput(
+          {
+            ...bookHydrated,
+            publishedDate: null,
+          },
+          'America/Chicago',
+        ),
+      ).toEqual({
+        ...bookFormInput,
+        publishedDate: '',
+      });
+    });
+  });
+});

--- a/src/lib/transformers/book.ts
+++ b/src/lib/transformers/book.ts
@@ -1,0 +1,25 @@
+import { convertCentsToDollars } from '@/lib/money';
+import BookFormInput from '@/types/BookFormInput';
+import BookHydrated from '@/types/BookHydrated';
+import { format } from 'date-fns';
+import { zonedTimeToUtc } from 'date-fns-tz';
+
+export function transformBookHydratedToBookFormInput(
+  book: BookHydrated,
+  timezone: string,
+): BookFormInput {
+  return {
+    authors: book.authors.map((a) => a.name).join(', '),
+    format: book.format,
+    genre: book.genre,
+    imageUrl: book.imageUrl,
+    isbn13: book.isbn13.toString(),
+    priceInCents: convertCentsToDollars(book.priceInCents).toString(),
+    publishedDate: book.publishedDate
+      ? format(zonedTimeToUtc(book.publishedDate, timezone), 'yyyy-MM-dd')
+      : '',
+    publisher: book.publisher.name,
+    quantity: book.quantity.toString(),
+    title: book.title,
+  };
+}


### PR DESCRIPTION
- add book search, findBookByIsbn13, which first searches internally to find the book and returns that if it exists, else uses the google book search.
- use this book search in the BookForm so we pull our internal book first if it exists. This also fixes a bug where we'd write 0 quantity each time we re-add a book that already exists.
- add a transformer function to convert from BookHydrated to BookFormInput. Future transformers will probably follow