### PR TITLE
feat: ProductType

### DIFF
--- a/prisma/migrations/20240229164226_product_type/migration.sql
+++ b/prisma/migrations/20240229164226_product_type/migration.sql
@@ -1,0 +1,13 @@
+-- CreateEnum
+CREATE TYPE "ProductType" AS ENUM ('BOOK');
+
+-- AlterTable
+ALTER TABLE "InvoiceItem"
+ADD COLUMN     "productType" "ProductType" NOT NULL,
+ALTER COLUMN "bookId" DROP NOT NULL;
+
+-- We want to retain the foreign key constraint, so that if the bookId exists, we restrict delete
+-- DropForeignKey
+-- ALTER TABLE "InvoiceItem" DROP CONSTRAINT "InvoiceItem_bookId_fkey";
+-- AddForeignKey
+-- ALTER TABLE "InvoiceItem" ADD CONSTRAINT "InvoiceItem_bookId_fkey" FOREIGN KEY ("bookId") REFERENCES "Book"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -80,11 +80,13 @@ model InvoiceItem {
   quantity         Int
   totalCostInCents Int
 
-  book   Book @relation(fields: [bookId], references: [id])
-  bookId Int
-
   invoice   Invoice @relation(fields: [invoiceId], references: [id])
   invoiceId Int
+
+  productType ProductType
+
+  book   Book? @relation(fields: [bookId], references: [id])
+  bookId Int?
 }
 
 enum Format {
@@ -109,4 +111,10 @@ enum Genre {
   // Non-Fiction
   BUSINESS_AND_FINANCE
   COOKBOOKS
+}
+
+enum ProductType {
+  BOOK
+
+  // eventually other product types like general merchandise, etc
 }

--- a/src/app/invoices/[id]/BookForm.tsx
+++ b/src/app/invoices/[id]/BookForm.tsx
@@ -15,6 +15,7 @@ import BookCreateInput from '@/types/BookCreateInput';
 import BookFormInput from '@/types/BookFormInput';
 import InvoiceHydrated from '@/types/InvoiceHydrated';
 import InvoiceItemCreateInput from '@/types/InvoiceItemCreateInput';
+import { ProductType } from '@prisma/client';
 import { ReloadIcon } from '@radix-ui/react-icons';
 import _ from 'lodash';
 import Image from 'next/image';
@@ -163,6 +164,7 @@ export default function BookForm({
           book,
           invoiceId: invoice.id,
           itemCostInCents,
+          productType: ProductType.BOOK,
           quantity,
           totalCostInCents,
         };

--- a/src/components/invoice-item/InvoiceItemsTable.tsx
+++ b/src/components/invoice-item/InvoiceItemsTable.tsx
@@ -1,7 +1,9 @@
 import DataTable from '@/components/table/DataTable';
 import SortableHeader from '@/components/table/SortableHeader';
+import BookHydrated from '@/types/BookHydrated';
 import InvoiceItemHydrated from '@/types/InvoiceItemHydrated';
 import { ColumnDef } from '@tanstack/react-table';
+import Image from 'next/image';
 
 function RenderMoney({ value }: { value: number }) {
   return <>${value / 100}</>;
@@ -9,30 +11,38 @@ function RenderMoney({ value }: { value: number }) {
 
 const columns: ColumnDef<InvoiceItemHydrated>[] = [
   {
-    accessorFn: (invoiceItem) => invoiceItem.book.isbn13,
+    accessorFn: (invoiceItem) => invoiceItem.book?.isbn13,
     header: ({ column }) => (
-      <SortableHeader column={column} text="ISBN" className="justify-start" />
+      <SortableHeader column={column} text="SKU" className="justify-start" />
     ),
     id: 'isbn',
   },
   {
-    accessorFn: (invoiceItem) => invoiceItem.book.title,
-    header: ({ column }) => (
-      <SortableHeader column={column} text="Title" className="justify-start" />
-    ),
-    id: 'title',
+    accessorFn: (invoiceItem) => invoiceItem.book,
+    cell: (props) => {
+      const book = props.getValue() as BookHydrated | null;
+
+      return (
+        <div className="flex items-center">
+          {book?.imageUrl && (
+            <Image
+              alt={book.title}
+              src={book.imageUrl}
+              width={16}
+              height={24}
+            />
+          )}
+        </div>
+      );
+    },
+    header: 'Image',
   },
   {
-    accessorFn: (invoiceItem) =>
-      invoiceItem.book.authors.map((a) => a.name).join(', '),
+    accessorFn: (invoiceItem) => invoiceItem.book?.title,
     header: ({ column }) => (
-      <SortableHeader
-        column={column}
-        text="Authors"
-        className="justify-start"
-      />
+      <SortableHeader column={column} text="Name" className="justify-start" />
     ),
-    id: 'author',
+    id: 'title',
   },
   {
     accessorKey: 'itemCostInCents',

--- a/src/components/stories/invoice-item/InvoiceItemsTable.stories.tsx
+++ b/src/components/stories/invoice-item/InvoiceItemsTable.stories.tsx
@@ -1,0 +1,39 @@
+import InvoiceItemsTable from '@/components/invoice-item/InvoiceItemsTable';
+import { fakeInvoiceItemHydrated } from '@/lib/fakes/invoice-item';
+import InvoiceItemHydrated from '@/types/InvoiceItemHydrated';
+import { Meta, StoryObj } from '@storybook/react';
+import _ from 'lodash';
+
+const meta: Meta<typeof InvoiceItemsTable> = {
+  component: InvoiceItemsTable,
+};
+
+export default meta;
+type Story = StoryObj<typeof InvoiceItemsTable>;
+
+function getInvoiceItems() {
+  return _.times(9, (): InvoiceItemHydrated => {
+    const invoiceItem = fakeInvoiceItemHydrated();
+    return Math.random() > 0.2
+      ? invoiceItem
+      : {
+          ...invoiceItem,
+          book: {
+            ...invoiceItem.book!,
+            imageUrl: null,
+          },
+        };
+  });
+}
+
+export const Default: Story = {
+  render: () => {
+    const invoiceItems = getInvoiceItems();
+
+    return (
+      <div>
+        <InvoiceItemsTable invoiceItems={invoiceItems} />
+      </div>
+    );
+  },
+};

--- a/src/lib/actions/invoice.ts
+++ b/src/lib/actions/invoice.ts
@@ -11,7 +11,7 @@ import InvoiceCreateInput from '@/types/InvoiceCreateInput';
 import InvoiceHydrated from '@/types/InvoiceHydrated';
 import PageInfo from '@/types/PageInfo';
 import PaginationQuery from '@/types/PaginationQuery';
-import { Invoice, Prisma } from '@prisma/client';
+import { Invoice, Prisma, ProductType } from '@prisma/client';
 
 export async function createInvoice(
   invoice: InvoiceCreateInput,
@@ -74,6 +74,14 @@ export async function completeInvoice(
   // condense all the book updates by book ID
   const bookUpdates = invoiceItems.reduce(
     (acc, item) => {
+      if (item.productType !== ProductType.BOOK || item.bookId === null) {
+        logger.warn(
+          'non-book product type encountered, skipping invoice item: %j',
+          item,
+        );
+        return acc;
+      }
+
       const match = acc.find((i) => i.id === item.bookId);
       if (match) {
         match.increasedQuantity += item.quantity;

--- a/src/lib/fakes/invoice-item.ts
+++ b/src/lib/fakes/invoice-item.ts
@@ -3,7 +3,7 @@ import { fakeCreatedAtUpdatedAt } from '@/lib/fakes/created-at-updated-at';
 import { convertDollarsToCents } from '@/lib/money';
 import InvoiceItemHydrated from '@/types/InvoiceItemHydrated';
 import { faker } from '@faker-js/faker';
-import { InvoiceItem } from '@prisma/client';
+import { InvoiceItem, ProductType } from '@prisma/client';
 
 export function fakeInvoiceItem(): InvoiceItem {
   const itemCostInCents =
@@ -18,6 +18,7 @@ export function fakeInvoiceItem(): InvoiceItem {
     id: faker.number.int(),
     invoiceId: faker.number.int(),
     itemCostInCents,
+    productType: ProductType.BOOK,
     quantity,
     totalCostInCents,
   };

--- a/src/types/InvoiceItemCreateInput.ts
+++ b/src/types/InvoiceItemCreateInput.ts
@@ -5,6 +5,6 @@ type InvoiceItemCreateInput = Omit<
   InvoiceItem,
   'id' | 'createdAt' | 'updatedAt' | 'bookId'
 > & {
-  book: BookCreateInput;
+  book?: BookCreateInput;
 };
 export default InvoiceItemCreateInput;

--- a/src/types/InvoiceItemHydrated.ts
+++ b/src/types/InvoiceItemHydrated.ts
@@ -2,6 +2,6 @@ import BookHydrated from '@/types/BookHydrated';
 import { InvoiceItem } from '@prisma/client';
 
 type InvoiceItemHydrated = InvoiceItem & {
-  book: BookHydrated;
+  book?: BookHydrated;
 };
 export default InvoiceItemHydrated;


### PR DESCRIPTION
In the future, we (may) want to sell things other than books. So to build for that now, add a ProductType enum to the database schema with a single value BOOK. Then within InvoiceItem, include the ProductType and make the book/bookId optional.

Make updates to the code to account for this new ability, mostly skipping types other than BOOK since we have no other type at this time.

Adjust the InvoiceItemsTable to be more generic in how it describes each item, add an image to the table, and add stories to demo.