### PR TITLE
chore: ProductType migration resolution

### DIFF
--- a/prisma/migrations/20240229164226_product_type/migration.sql
+++ b/prisma/migrations/20240229164226_product_type/migration.sql
@@ -6,8 +6,7 @@ ALTER TABLE "InvoiceItem"
 ADD COLUMN     "productType" "ProductType" NOT NULL,
 ALTER COLUMN "bookId" DROP NOT NULL;
 
--- We want to retain the foreign key constraint, so that if the bookId exists, we restrict delete
 -- DropForeignKey
--- ALTER TABLE "InvoiceItem" DROP CONSTRAINT "InvoiceItem_bookId_fkey";
+ALTER TABLE "InvoiceItem" DROP CONSTRAINT "InvoiceItem_bookId_fkey";
 -- AddForeignKey
--- ALTER TABLE "InvoiceItem" ADD CONSTRAINT "InvoiceItem_bookId_fkey" FOREIGN KEY ("bookId") REFERENCES "Book"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "InvoiceItem" ADD CONSTRAINT "InvoiceItem_bookId_fkey" FOREIGN KEY ("bookId") REFERENCES "Book"("id") ON DELETE SET NULL ON UPDATE CASCADE;


### PR DESCRIPTION
- The original migration was modified manually prior to commit. Now any new changes re-generate this change. The change is not necessary, so let's just commit the changes made by prisma.