### PR TITLE
test: extend invoice e2e test

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -21,16 +21,14 @@ export default defineConfig({
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
     },
-
-    {
-      name: 'firefox',
-      use: { ...devices['Desktop Firefox'] },
-    },
-
-    {
-      name: 'webkit',
-      use: { ...devices['Desktop Safari'] },
-    },
+    // {
+    //   name: 'firefox',
+    //   use: { ...devices['Desktop Firefox'] },
+    // },
+    // {
+    //   name: 'webkit',
+    //   use: { ...devices['Desktop Safari'] },
+    // },
 
     /* Test against mobile viewports. */
     // {
@@ -54,9 +52,8 @@ export default defineConfig({
   ],
 
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
-  /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? 'dot' : 'html',
+  retries: 0,
   testDir: './tests',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {

--- a/src/app/invoices/[id]/BookForm.tsx
+++ b/src/app/invoices/[id]/BookForm.tsx
@@ -55,13 +55,15 @@ function BookFormInputField({
 
   return (
     <div className="flex flex-col flex-1">
-      <label className="text-sm capitalize">{fieldNameToDisplay}</label>
-      <Input
-        step={type === 'number' ? 'any' : ''}
-        type={type}
-        variant={errors[fieldName] ? 'error' : 'default'}
-        {...register(fieldName, { required: true })}
-      />
+      <label className="text-sm capitalize">
+        {fieldNameToDisplay}
+        <Input
+          step={type === 'number' ? 'any' : ''}
+          type={type}
+          variant={errors[fieldName] ? 'error' : 'default'}
+          {...register(fieldName, { required: true })}
+        />
+      </label>
     </div>
   );
 }
@@ -92,7 +94,11 @@ export default function BookForm({
     handleSubmit: handleSearchSubmit,
     register: registerSearchSubmit,
     reset: resetSearchSubmit,
-  } = useForm<SearchFormInput>();
+  } = useForm<SearchFormInput>({
+    values: {
+      input: '',
+    },
+  });
   const { ref: formRef, ...formRest } = registerSearchSubmit('input');
 
   const onSearch = useCallback(
@@ -149,11 +155,11 @@ export default function BookForm({
   const onBookSubmit: SubmitHandler<BookFormInput> = useCallback(
     async (bookFormInput) => {
       if (invoice) {
-        const book: BookCreateInput =
-          await transformBookFormInputToBookCreateInput({
-            bookFormInput,
-            quantity: lookupBook?.quantity,
-          });
+        const book: BookCreateInput = transformBookFormInputToBookCreateInput({
+          bookFormInput,
+          quantity: lookupBook?.quantity,
+          timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+        });
 
         const { discountPercentage } = invoice.vendor;
 
@@ -200,16 +206,18 @@ export default function BookForm({
             onSubmit={handleSearchSubmit(onSearch)}
           >
             <div className="flex flex-col">
-              <label className="text-sm capitalize">Scan or Enter ISBN</label>
-              <Input
-                {...formRest}
-                ref={(e) => {
-                  formRef(e);
-                  searchRef.current = e;
-                }}
-                type="text"
-                className="w-[300px]"
-              />
+              <label className="text-sm capitalize">
+                Scan or Enter SKU
+                <Input
+                  {...formRest}
+                  ref={(e) => {
+                    formRef(e);
+                    searchRef.current = e;
+                  }}
+                  type="text"
+                  className="w-[300px]"
+                />
+              </label>
             </div>
             <Button variant="default" type="submit" className="w-[100px]">
               {isSearching ? (

--- a/src/app/invoices/[id]/BookFormSelectFormat.tsx
+++ b/src/app/invoices/[id]/BookFormSelectFormat.tsx
@@ -38,7 +38,10 @@ export default function BookFormSelectFormat({
         onValueChange={onValueChange}
         value={selectedFormatId?.toString()}
       >
-        <SelectTrigger className={clsx(hasError ? 'border-red-500' : '')}>
+        <SelectTrigger
+          className={clsx(hasError ? 'border-red-500' : '')}
+          data-testid="select-format"
+        >
           <SelectValue placeholder="Select Format..." />
         </SelectTrigger>
         <SelectContent>

--- a/src/app/invoices/[id]/BookFormSelectGenre.tsx
+++ b/src/app/invoices/[id]/BookFormSelectGenre.tsx
@@ -33,7 +33,10 @@ export default function BookFormSelectGenre({
     <div className="flex flex-col flex-1">
       <label className="text-sm capitalize">Genre</label>
       <Select onValueChange={onValueChange} value={selectedGenreId?.toString()}>
-        <SelectTrigger className={clsx(hasError ? 'border-red-500' : '')}>
+        <SelectTrigger
+          className={clsx(hasError ? 'border-red-500' : '')}
+          data-testid="select-genre"
+        >
           <SelectValue placeholder="Select Genre..." />
         </SelectTrigger>
         <SelectContent>

--- a/src/app/invoices/[id]/InvoiceDescription.tsx
+++ b/src/app/invoices/[id]/InvoiceDescription.tsx
@@ -13,7 +13,9 @@ export default function InvoiceDescription({
       data-testid="invoice-description"
     >
       <div className="flex flex-col">
-        <div className="font-bold">{vendor.name}</div>
+        <div className="font-bold" data-testid="vendor-name">
+          {vendor.name}
+        </div>
         <div className="grid grid-cols-2 gap-0">
           <div>
             <div>Discount:</div>
@@ -33,8 +35,10 @@ export default function InvoiceDescription({
             {invoice.isCompleted && <div>Received:</div>}
           </div>
           <div className="text-right">
-            <div>{invoice.invoiceNumber}</div>
-            <div>{invoice.invoiceDate.toLocaleDateString()}</div>
+            <div data-testid="invoice-number">{invoice.invoiceNumber}</div>
+            <div data-testid="invoice-date">
+              {invoice.invoiceDate.toLocaleDateString()}
+            </div>
             {invoice.isCompleted && (
               <div>{invoice.dateReceived?.toLocaleDateString()}</div>
             )}

--- a/src/components/book/Book.tsx
+++ b/src/components/book/Book.tsx
@@ -30,7 +30,7 @@ function BookKey({
       break;
     case 'priceInCents':
       fieldNameToDisplay = 'Price';
-      fieldToDisplay = `$${convertCentsToDollars(book[fieldName])}`;
+      fieldToDisplay = `$${convertCentsToDollars(book[fieldName]).toFixed(2)}`;
       break;
     case 'publishedDate':
       fieldNameToDisplay = 'Published Date';
@@ -56,7 +56,7 @@ function BookKey({
 
 export default function Book({ book }: { book: BookHydrated }) {
   return (
-    <div className="flex gap-4 h-[192px]">
+    <div className="flex gap-4 h-[192px]" data-testid={`${book.isbn13}`}>
       {book.imageUrl ? (
         <Image alt={book.title} src={book.imageUrl} width={128} height={192} />
       ) : (

--- a/src/components/invoice-item/InvoiceItemsTable.tsx
+++ b/src/components/invoice-item/InvoiceItemsTable.tsx
@@ -6,7 +6,7 @@ import { ColumnDef } from '@tanstack/react-table';
 import Image from 'next/image';
 
 function RenderMoney({ value }: { value: number }) {
-  return <>${value / 100}</>;
+  return <>${(value / 100).toFixed(2)}</>;
 }
 
 const columns: ColumnDef<InvoiceItemHydrated>[] = [

--- a/src/components/invoice/InvoiceCreate.tsx
+++ b/src/components/invoice/InvoiceCreate.tsx
@@ -12,6 +12,7 @@ import {
   SheetTrigger,
 } from '@/components/ui/sheet';
 import BookSourceSerialized from '@/types/BookSourceSerialized';
+import { zonedTimeToUtc } from 'date-fns-tz';
 import { useCallback, useState } from 'react';
 import { SubmitHandler, useForm } from 'react-hook-form';
 
@@ -45,7 +46,12 @@ export default function InvoiceCreate({
     (data: InvoiceCreateFormInput) => {
       onCreate({
         ...data,
-        invoiceDate: new Date(data.invoiceDate),
+        invoiceDate: new Date(
+          zonedTimeToUtc(
+            data.invoiceDate,
+            Intl.DateTimeFormat().resolvedOptions().timeZone,
+          ),
+        ),
       });
       reset();
       setIsOpen(false);

--- a/src/lib/money.test.ts
+++ b/src/lib/money.test.ts
@@ -61,6 +61,15 @@ describe('money', () => {
         }),
       ).toEqual(0);
     });
+
+    it('should work with non-round numbers', () => {
+      expect(
+        determineDiscountedAmountInCents({
+          discountPercentage: 0.4,
+          priceInCents: 2699,
+        }),
+      ).toEqual(1619);
+    });
   });
 
   describe('discountPercentageToDisplayString', () => {

--- a/src/lib/money.ts
+++ b/src/lib/money.ts
@@ -16,7 +16,7 @@ export function determineDiscountedAmountInCents({
   priceInCents: number;
   discountPercentage: number;
 }): number {
-  const cost = priceInCents - priceInCents * discountPercentage;
+  const cost = priceInCents - _.round(priceInCents * discountPercentage);
   return cost;
 }
 

--- a/src/lib/transformers/book.test.ts
+++ b/src/lib/transformers/book.test.ts
@@ -71,7 +71,7 @@ describe('book transformers', () => {
     imageUrl: 'http://image.com',
     isbn13: BigInt('987'),
     priceInCents: 1999,
-    publishedDate: new Date('2000-01-02T00:00:00.000Z'),
+    publishedDate: new Date('2000-01-02T06:00:00.000Z'),
     publisher: 'Publisher 1',
     quantity: 12,
     title: 'My Book',
@@ -117,6 +117,7 @@ describe('book transformers', () => {
         transformBookFormInputToBookCreateInput({
           bookFormInput,
           quantity: '42',
+          timezone: 'America/Chicago',
         }),
       ).toEqual({
         ...bookCreateInput,
@@ -128,6 +129,7 @@ describe('book transformers', () => {
       expect(
         transformBookFormInputToBookCreateInput({
           bookFormInput,
+          timezone: 'America/Chicago',
         }),
       ).toEqual({
         ...bookCreateInput,
@@ -142,6 +144,7 @@ describe('book transformers', () => {
             ...bookFormInput,
             formatId: undefined,
           },
+          timezone: 'America/Chicago',
         }),
       ).toThrowErrorMatchingInlineSnapshot(`"formatId required"`);
     });
@@ -153,6 +156,7 @@ describe('book transformers', () => {
             ...bookFormInput,
             genreId: undefined,
           },
+          timezone: 'America/Chicago',
         }),
       ).toThrowErrorMatchingInlineSnapshot(`"genreId required"`);
     });

--- a/src/lib/transformers/book.ts
+++ b/src/lib/transformers/book.ts
@@ -3,6 +3,7 @@ import { convertCentsToDollars, convertDollarsToCents } from '@/lib/money';
 import BookCreateInput from '@/types/BookCreateInput';
 import BookFormInput from '@/types/BookFormInput';
 import BookHydrated from '@/types/BookHydrated';
+import { zonedTimeToUtc } from 'date-fns-tz';
 import _ from 'lodash';
 
 export function transformBookHydratedToBookFormInput({
@@ -31,9 +32,11 @@ export function transformBookHydratedToBookFormInput({
 export function transformBookFormInputToBookCreateInput({
   bookFormInput,
   quantity,
+  timezone,
 }: {
   bookFormInput: BookFormInput;
   quantity?: string;
+  timezone: string;
 }): BookCreateInput {
   const {
     formatId,
@@ -60,7 +63,7 @@ export function transformBookFormInputToBookCreateInput({
     isbn13: BigInt(isbn13),
     // the book form input is presented as dollars, so convert to cents
     priceInCents: convertDollarsToCents(priceInCents),
-    publishedDate: new Date(publishedDate),
+    publishedDate: zonedTimeToUtc(publishedDate, timezone),
     quantity: _.toNumber(quantity || 0),
   };
 }

--- a/tests/invoices.spec.ts
+++ b/tests/invoices.spec.ts
@@ -1,10 +1,228 @@
+import { InvoiceCreateFormInput } from '@/components/invoice/InvoiceCreate';
+import BookFormInput from '@/types/BookFormInput';
 import { faker } from '@faker-js/faker';
-import { test, expect } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
+import { format } from 'date-fns';
+import _ from 'lodash';
+
+type InvoiceCreateFormInputStrings = Omit<
+  InvoiceCreateFormInput,
+  'vendorId'
+> & {
+  vendor: string;
+};
+
+type BookFormInputStrings = Omit<
+  BookFormInput,
+  'formatId' | 'genreId' | 'imageUrl' | 'priceInCents'
+> & {
+  format: string;
+  genre: string;
+  price: string;
+};
+
+async function createInvoice({
+  invoice,
+  page,
+}: {
+  invoice: InvoiceCreateFormInputStrings;
+  page: Page;
+}) {
+  await page.getByRole('button', { name: 'New Invoice' }).click();
+  await expect(page.getByRole('heading', { level: 2 })).toHaveText(
+    'New Invoice',
+  );
+  await page.getByLabel('Number').fill(invoice.invoiceNumber);
+  await page.getByLabel('Date').fill(format(invoice.invoiceDate, 'yyyy-MM-dd'));
+  await page.getByTestId('select-vendor').click();
+  await page.getByLabel(invoice.vendor).click();
+  await page.getByRole('button', { name: 'Create' }).click();
+}
+
+async function verifyInvoiceDetails({
+  invoice,
+  isComplete,
+  page,
+}: {
+  invoice: InvoiceCreateFormInputStrings;
+  isComplete: boolean;
+  page: Page;
+}) {
+  const invoiceDescription = page.getByTestId('invoice-description');
+  await expect(invoiceDescription.getByTestId('vendor-name')).toHaveText(
+    'Vendor One',
+  );
+  await expect(
+    invoiceDescription.getByTestId('discount-percentage'),
+  ).toHaveText('40%');
+  await expect(invoiceDescription.getByTestId('invoice-number')).toHaveText(
+    invoice.invoiceNumber,
+  );
+  await expect(invoiceDescription.getByTestId('invoice-date')).toHaveText(
+    format(invoice.invoiceDate, 'M/d/yyyy'),
+  );
+
+  if (isComplete) {
+    await expect(invoiceDescription.getByText('Received')).toBeVisible();
+  } else {
+    await expect(invoiceDescription.getByText('Received')).not.toBeVisible();
+  }
+}
+
+async function enterInNewBook({
+  book,
+  page,
+  itemCost,
+  totalCost,
+}: {
+  book: BookFormInputStrings;
+  page: Page;
+  itemCost: string;
+  totalCost: string;
+}) {
+  // enter in an ISBN and press enter
+  const skuInput = page.getByLabel('Scan or Enter SKU');
+  await skuInput.fill(book.isbn13);
+  await skuInput.press('Enter');
+
+  // verify the book form
+  await expect(page.getByLabel('ISBN')).toHaveValue(book.isbn13);
+  await expect(page.getByLabel('Title')).toHaveValue(book.title);
+  await expect(page.getByLabel('Authors')).toHaveValue(book.authors);
+
+  // fill in the custom values
+  await page.getByTestId('select-genre').click();
+  await page.getByLabel(book.genre, { exact: true }).click();
+  await page.getByTestId('select-format').click();
+  await page.getByLabel(book.format).click();
+  await page.getByLabel('Price').fill(book.price);
+
+  await expect(page.getByLabel('Publisher')).toHaveValue(book.publisher);
+  await expect(page.getByLabel('Published Date')).toHaveValue(
+    book.publishedDate,
+  );
+  await expect(page.getByLabel('Quantity')).toHaveValue(book.quantity);
+
+  // add the book, creating the invoice item
+  await page.getByRole('button', { name: 'Add' }).click();
+
+  // verify the row added to the table
+  const row = page.getByRole('row').nth(1);
+  await expect(row).toHaveText(
+    `${book.isbn13}${book.title}$${itemCost}${book.quantity}$${totalCost}`,
+  );
+}
+
+async function enterInExistingBook({
+  additionalQuantity,
+  book,
+  page,
+  itemCost,
+  totalCost,
+}: {
+  additionalQuantity?: string;
+  book: BookFormInputStrings;
+  page: Page;
+  itemCost: string;
+  totalCost: string;
+}) {
+  // enter in an ISBN and press enter
+  const skuInput = page.getByLabel('Scan or Enter SKU');
+  await skuInput.fill(book.isbn13);
+  await skuInput.press('Enter');
+
+  // verify the book form (custom values now show by default)
+  await expect(page.getByLabel('ISBN')).toHaveValue(book.isbn13);
+  await expect(page.getByLabel('Title')).toHaveValue(book.title);
+  await expect(page.getByLabel('Authors')).toHaveValue(book.authors);
+  await expect(page.getByTestId('select-genre')).toHaveText(book.genre);
+  await expect(page.getByTestId('select-format')).toHaveText(book.format);
+  await expect(page.getByLabel('Price')).toHaveValue(book.price);
+  await expect(page.getByLabel('Publisher')).toHaveValue(book.publisher);
+  await expect(page.getByLabel('Published Date')).toHaveValue(
+    book.publishedDate,
+  );
+
+  // add additional quantity if asked
+  let quantity: string;
+  if (additionalQuantity) {
+    quantity = additionalQuantity;
+    await page.getByLabel('Quantity').fill(additionalQuantity);
+  } else {
+    quantity = book.quantity;
+    await expect(page.getByLabel('Quantity')).toHaveValue(book.quantity);
+  }
+
+  // add the book, creating the invoice item
+  await page.getByRole('button', { name: 'Add' }).click();
+
+  // verify the row added to the table
+  const row = page.getByRole('row').nth(1);
+  await expect(row).toHaveText(
+    `${book.isbn13}${book.title}$${itemCost}${quantity}$${totalCost}`,
+  );
+}
+
+async function verifyBookDetails({
+  book,
+  page,
+  quantity,
+}: {
+  book: BookFormInputStrings;
+  page: Page;
+  quantity: string;
+}) {
+  const bookComponent = page.getByTestId(book.isbn13);
+
+  await expect(bookComponent.getByText(book.title)).toBeVisible();
+  await expect(bookComponent.getByText(`ISBN:${book.isbn13}`)).toBeVisible();
+  await expect(bookComponent.getByText(`By:${book.authors}`)).toBeVisible();
+  await expect(bookComponent.getByText(`Format:${book.format}`)).toBeVisible();
+  await expect(bookComponent.getByText(`Genre:${book.genre}`)).toBeVisible();
+  await expect(bookComponent.getByText(`Price:$${book.price}`)).toBeVisible();
+  await expect(bookComponent.getByText(`Quantity:${quantity}`)).toBeVisible();
+}
 
 test.describe('invoices', () => {
-  test('create invoice, add items, complete to add inventory', async ({
+  test('create invoice, add books, complete to add inventory', async ({
     page,
   }) => {
+    const invoice: InvoiceCreateFormInputStrings = {
+      invoiceDate: faker.date.past(),
+      invoiceNumber: faker.finance.accountNumber().toString(),
+      vendor: 'Vendor One',
+    };
+
+    const book1: BookFormInputStrings = {
+      authors: 'Brandon Sanderson',
+      format: 'Trade Paperback',
+      genre: 'Fantasy',
+      isbn13: '9780765376671',
+      price: '26.99',
+      publishedDate: '2014-03-04',
+      publisher: 'Macmillan',
+      quantity: '1',
+      title: 'The Way of Kings',
+    };
+    // 40% off of the price
+    const book1Cost = '16.19';
+    const book1AdditionalQuantity = '3';
+    const book1AdditionalQuantityTotalCost = '48.57';
+
+    const book2: BookFormInputStrings = {
+      authors: 'Sarah J. Maas',
+      format: 'Trade Paperback',
+      genre: 'Romance',
+      isbn13: '9781635575569',
+      price: '19.00',
+      publishedDate: '2020-06-02',
+      publisher: 'Bloomsbury Publishing USA',
+      quantity: '1',
+      title: 'A Court of Thorns and Roses',
+    };
+    // 40% off of the price
+    const book2Cost = '11.40';
+
     await page.goto('/');
     await expect(page.getByRole('main')).toHaveText('Welcome');
 
@@ -13,30 +231,64 @@ test.describe('invoices', () => {
     await page.getByText('Invoices').click();
     await expect(page.getByRole('heading')).toHaveText('Invoices');
 
-    // create new invoice
-    const invoiceNumber = faker.finance.accountNumber().toString();
-    await page.getByRole('button', { name: 'New Invoice' }).click();
-    await expect(page.getByRole('heading', { level: 2 })).toHaveText(
-      'New Invoice',
-    );
-    await page.getByLabel('Number').fill(invoiceNumber);
-    await page.getByLabel('Date').fill('2024-03-01');
-    await page.getByTestId('select-vendor').click();
-    await page.getByLabel('Vendor One').click();
-    await page.getByRole('button', { name: 'Create' }).click();
+    await createInvoice({ invoice, page });
 
     // find the newly created invoice in the table
-    await expect(page.getByRole('cell', { name: invoiceNumber })).toBeVisible();
+    await expect(
+      page.getByRole('cell', { name: invoice.invoiceNumber }),
+    ).toBeVisible();
 
     // navigate to the invoice item page
-    await page.getByRole('cell', { name: invoiceNumber }).click();
+    await page.getByRole('cell', { name: invoice.invoiceNumber }).click();
 
-    // verify the invoice details are shown
-    await expect(
-      page.getByTestId('invoice-description').getByText('Vendor One'),
-    ).toBeVisible();
-    await expect(page.getByTestId('discount-percentage')).toHaveText('40%');
+    await verifyInvoiceDetails({ invoice, isComplete: false, page });
 
-    // TODO add items and complete
+    // create invoice item for book1
+    await enterInNewBook({
+      book: book1,
+      itemCost: book1Cost,
+      page,
+      totalCost: book1Cost,
+    });
+
+    // create second invoice item for book1
+    await enterInExistingBook({
+      additionalQuantity: book1AdditionalQuantity,
+      book: book1,
+      itemCost: book1Cost,
+      page,
+      totalCost: book1AdditionalQuantityTotalCost,
+    });
+
+    // create invoice item for book2
+    await enterInNewBook({
+      book: book2,
+      itemCost: book2Cost,
+      page,
+      totalCost: book2Cost,
+    });
+
+    // complete invoice
+    await page.getByRole('button', { name: 'Complete Invoice' }).click();
+
+    await verifyInvoiceDetails({ invoice, isComplete: true, page });
+
+    // navigate to the list books page
+    await page.getByRole('navigation').getByTestId('nav-menu').click();
+    await page.getByText('List').click();
+    await expect(page.getByRole('heading')).toHaveText('Books');
+
+    await verifyBookDetails({
+      book: book1,
+      page,
+      quantity: (
+        _.toNumber(book1.quantity) + _.toNumber(book1AdditionalQuantity)
+      ).toString(),
+    });
+    await verifyBookDetails({
+      book: book2,
+      page,
+      quantity: book2.quantity,
+    });
   });
 });


### PR DESCRIPTION
- add additional content to the e2e test for invoices
- Configure playwright to only run against chrome, since the e2e test changes state and running multiple times affects the test. Also no retries, and set reporter to dot in CI.
- fix some issues with timezones found during testing
- fix some issues with display found in testing, wrap inputs with labels
- add more data-testid's