### PR TITLE
feat: vercel integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "node": "20.x"
   },
   "scripts": {
-    "build": "next build",
+    "build": "prisma generate && next build",
     "build-storybook": "storybook build",
     "check-types": "tsc --noemit",
     "ci:db": "bun run ci:db:reset & bun run ci:db:seed",


### PR DESCRIPTION
- add `prisma generate` to the build command as instructed by prisma when integrating with vercel: https://www.prisma.io/docs/orm/more/help-and-troubleshooting/help-articles/vercel-caching-issue