### PR TITLE
feat: order actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
     "lint": "bun run eslint && bun run check-types",
     "start": "next start",
     "storybook": "storybook dev -p 6006",
-    "test": "jest --coverage",
+    "test": "TZ=UTC jest --coverage",
     "test:e2e": "bun run ci:db && bun playwright test",
-    "test:watch": "jest --watch"
+    "test:watch": "TZ=UTC jest --watch"
   },
   "prisma": {
     "seed": "ts-node -r tsconfig-paths/register --compiler-options {\"module\":\"CommonJS\"} prisma/seed/run-fake.ts"

--- a/src/lib/actions/order-item.test.ts
+++ b/src/lib/actions/order-item.test.ts
@@ -1,0 +1,66 @@
+import { createOrderItem } from '@/lib/actions/order-item';
+import fakeOrderItem from '@/lib/fakes/order-item';
+import { prismaMock } from '../../../test-setup/prisma-mock.setup';
+import { fakeBook } from '@/lib/fakes/book';
+import { fakeOrder } from '@/lib/fakes/order';
+import { computeTax } from '@/lib/money';
+import { ProductType } from '@prisma/client';
+
+describe('order item actions', () => {
+  const order1 = fakeOrder();
+  const orderItem1 = fakeOrderItem();
+  const book1 = fakeBook();
+
+  describe('createInvoiceItem', () => {
+    it('should create order item', async () => {
+      prismaMock.$transaction.mockImplementation((cb) => cb(prismaMock));
+      prismaMock.book.findUniqueOrThrow.mockResolvedValue(book1);
+      prismaMock.order.findUniqueOrThrow.mockResolvedValue(order1);
+      prismaMock.order.update.mockResolvedValue(order1);
+      orderItem1.orderId = order1.id;
+      orderItem1.bookId = book1.id;
+      prismaMock.orderItem.create.mockResolvedValue(orderItem1);
+
+      await createOrderItem(orderItem1);
+
+      expect(prismaMock.orderItem.create).toHaveBeenCalledWith({
+        data: {
+          book: {
+            connect: { id: book1.id },
+          },
+          order: {
+            connect: { id: order1.id },
+          },
+          productPriceInCents: book1.priceInCents,
+          productType: ProductType.BOOK,
+          quantity: orderItem1.quantity,
+          totalPriceInCents: orderItem1.quantity * book1.priceInCents,
+        },
+      });
+
+      const subTotalInCents =
+        order1.subTotalInCents + orderItem1.totalPriceInCents;
+      const taxInCents = computeTax(subTotalInCents);
+      const totalInCents = subTotalInCents + taxInCents;
+      expect(prismaMock.order.update).toHaveBeenCalledWith({
+        data: {
+          subTotalInCents,
+          taxInCents,
+          totalInCents,
+        },
+        where: { id: order1.id },
+      });
+    });
+
+    it('should throw error without book', async () => {
+      await expect(
+        createOrderItem({
+          ...orderItem1,
+          bookId: null,
+        }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `"bookId required as input at this time"`,
+      );
+    });
+  });
+});

--- a/src/lib/actions/order-item.ts
+++ b/src/lib/actions/order-item.ts
@@ -1,0 +1,52 @@
+'use server';
+
+import { recomputeOrderTotals } from '@/lib/actions/order';
+import logger from '@/lib/logger';
+import prisma from '@/lib/prisma';
+import OrderItemCreateInput from '@/types/OrderItemCreateInput';
+import { OrderItem, Prisma, ProductType } from '@prisma/client';
+
+export async function createOrderItem(
+  orderItem: OrderItemCreateInput,
+): Promise<OrderItem> {
+  const { bookId, orderId, quantity } = orderItem;
+
+  // we only handle order items of product type Book at this time
+  const productType = ProductType.BOOK;
+  if (!bookId) {
+    logger.error('createOrderItem asked to create without bookId');
+    throw new Error('bookId required as input at this time');
+  }
+
+  const book = await prisma.book.findUniqueOrThrow({ where: { id: bookId } });
+  const productPriceInCents = book.priceInCents;
+  const totalPriceInCents = productPriceInCents * quantity;
+
+  return prisma.$transaction(
+    async (tx) => {
+      const createdOrderItem = await tx.orderItem.create({
+        data: {
+          book: {
+            connect: { id: bookId },
+          },
+          order: {
+            connect: { id: orderId },
+          },
+          productPriceInCents,
+          productType,
+          quantity,
+          totalPriceInCents,
+        },
+      });
+
+      logger.trace('created order item in DB: %j', createdOrderItem);
+
+      await recomputeOrderTotals({ orderItem: createdOrderItem, tx });
+
+      return createdOrderItem;
+    },
+    {
+      isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+    },
+  );
+}

--- a/src/lib/actions/order.test.ts
+++ b/src/lib/actions/order.test.ts
@@ -1,0 +1,246 @@
+import { fakeOrder } from '@/lib/fakes/order';
+import { prismaMock } from '../../../test-setup/prisma-mock.setup';
+import { completeOrder, completeOrderOrThrow, createOrder } from './order';
+import { OrderState, ProductType } from '@prisma/client';
+import fakeOrderItem from '@/lib/fakes/order-item';
+import { fakeBook } from '@/lib/fakes/book';
+import NegativeBookQuantityError from '@/lib/errors/NegativeBookQuantityError';
+import BadRequestError from '@/lib/errors/BadRequestError';
+
+describe('order action', () => {
+  const order1 = fakeOrder();
+
+  beforeAll(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2021-02-03T12:13:14.000Z'));
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  describe('createOrder', () => {
+    it('should create a new order', async () => {
+      prismaMock.order.create.mockResolvedValue(order1);
+      prismaMock.order.update.mockResolvedValue(order1);
+
+      await createOrder();
+
+      expect(prismaMock.order.create).toHaveBeenCalledWith({
+        data: {
+          orderOpenedDate: new Date('2021-02-03T12:13:14.000Z'),
+          orderState: OrderState.OPEN,
+          subTotalInCents: 0,
+          taxInCents: 0,
+          totalInCents: 0,
+        },
+      });
+      expect(prismaMock.order.update).toHaveBeenCalledWith({
+        data: { orderUID: `210203121314-${order1.id}` },
+        where: { id: order1.id },
+      });
+    });
+  });
+
+  describe('completeOrderOrThrow', () => {
+    it('should complete the order', async () => {
+      prismaMock.$transaction.mockImplementation((cb) => cb(prismaMock));
+
+      const book1 = fakeBook();
+      book1.quantity = 7;
+      const item1 = fakeOrderItem();
+      item1.bookId = book1.id;
+      item1.quantity = 5;
+      prismaMock.book.findUniqueOrThrow.mockResolvedValueOnce(book1);
+
+      const book2 = fakeBook();
+      book2.quantity = 3;
+      const item2 = fakeOrderItem();
+      item2.bookId = book2.id;
+      item2.quantity = 3;
+      prismaMock.book.findUniqueOrThrow.mockResolvedValueOnce(book2);
+
+      const item3 = fakeOrderItem();
+      // item3 has same bookId as item1
+      item3.bookId = book1.id;
+      item3.quantity = 1;
+      prismaMock.book.findUniqueOrThrow.mockResolvedValueOnce(book1);
+
+      const order = {
+        ...order1,
+        orderItems: [item1, item2, item3],
+      };
+      prismaMock.order.findFirstOrThrow.mockResolvedValue(order);
+      prismaMock.order.update.mockResolvedValue(order);
+
+      await completeOrderOrThrow(order.id);
+
+      expect(prismaMock.order.findFirstOrThrow).toHaveBeenCalledWith({
+        include: { orderItems: true },
+        where: { id: order.id },
+      });
+
+      // 3 invoice items, but only 2 books total
+      expect(prismaMock.book.update).toHaveBeenCalledTimes(2);
+      expect(prismaMock.book.update).toHaveBeenNthCalledWith(1, {
+        // book1 - item1 - item3
+        data: { quantity: 7 - 5 - 1 },
+        where: { id: item1.bookId },
+      });
+      expect(prismaMock.book.update).toHaveBeenNthCalledWith(2, {
+        // book2 - item2
+        data: { quantity: 3 - 3 },
+        where: { id: item2.bookId },
+      });
+
+      expect(prismaMock.order.update).toHaveBeenCalledWith({
+        data: {
+          orderClosedDate: new Date('2021-02-03T12:13:14.000Z'),
+          orderState: OrderState.PAID,
+        },
+        where: { id: order.id },
+      });
+    });
+
+    it('should skip updating books for non-book product types', async () => {
+      prismaMock.$transaction.mockImplementation((cb) => cb(prismaMock));
+
+      const book1 = fakeBook();
+      book1.quantity = 7;
+      const item1 = fakeOrderItem();
+      item1.bookId = book1.id;
+      item1.quantity = 5;
+      prismaMock.book.findUniqueOrThrow.mockResolvedValueOnce(book1);
+
+      const item2 = fakeOrderItem();
+      // item2 is not a BOOK product type
+      item2.productType = 'foo' as ProductType;
+      item2.bookId = null;
+
+      const order = {
+        ...order1,
+        orderItems: [item1, item2],
+      };
+      prismaMock.order.findFirstOrThrow.mockResolvedValue(order);
+      prismaMock.order.update.mockResolvedValue(order);
+
+      await completeOrderOrThrow(order.id);
+
+      // 2 invoice items, but only 1 of type book
+      expect(prismaMock.book.update).toHaveBeenCalledTimes(1);
+    });
+
+    it('should throw NegativeBookQuantityError when attempting to complete order with insufficient inventory', async () => {
+      prismaMock.$transaction.mockImplementation((cb) => cb(prismaMock));
+
+      const book1 = fakeBook();
+      book1.quantity = 1;
+      const item1 = fakeOrderItem();
+      item1.bookId = book1.id;
+      // 2 is more than 1
+      item1.quantity = 2;
+      prismaMock.book.findUniqueOrThrow.mockResolvedValueOnce(book1);
+
+      const order = {
+        ...order1,
+        orderItems: [item1],
+      };
+      prismaMock.order.findFirstOrThrow.mockResolvedValue(order);
+      prismaMock.order.update.mockResolvedValue(order);
+
+      expect.assertions(3);
+      try {
+        await completeOrderOrThrow(order.id);
+      } catch (err) {
+        expect(err instanceof NegativeBookQuantityError).toBeTruthy();
+        const error: NegativeBookQuantityError =
+          err as NegativeBookQuantityError;
+        expect(error.book).toEqual(book1);
+        expect(error.message).toEqual(
+          'Attempting to set a negative quantity for Book',
+        );
+      }
+    });
+
+    it('should throw BadRequestError when attempting to complete order not in OPEN state', async () => {
+      const order = {
+        ...order1,
+        orderState: OrderState.PAID,
+      };
+      prismaMock.order.findFirstOrThrow.mockResolvedValue(order);
+
+      expect.assertions(2);
+      try {
+        await completeOrderOrThrow(order.id);
+      } catch (err) {
+        expect(err instanceof BadRequestError).toBeTruthy();
+        const error: BadRequestError = err as BadRequestError;
+        expect(error.message).toEqual(
+          'Order state must be in OPEN state to complete',
+        );
+      }
+    });
+  });
+
+  describe('completeOrder', () => {
+    it('should return the order when successful', async () => {
+      prismaMock.$transaction.mockImplementation((cb) => cb(prismaMock));
+      const order = {
+        ...order1,
+        orderItems: [],
+      };
+      prismaMock.order.findFirstOrThrow.mockResolvedValue(order);
+      prismaMock.order.update.mockResolvedValue(order);
+
+      expect(await completeOrder(1)).toEqual({
+        data: order,
+        status: 200,
+      });
+    });
+
+    it('should return error when completeOrderOrThrow throws BadRequestError', async () => {
+      // kinda hacky, but mocking this function is the simplest solution
+      prismaMock.order.findFirstOrThrow.mockRejectedValue(
+        new BadRequestError('bad input'),
+      );
+
+      expect(await completeOrder(1)).toEqual({
+        data: null,
+        error: {
+          message: 'bad input',
+          name: BadRequestError.name,
+        },
+        status: 400,
+      });
+    });
+
+    it('should return error when completeOrderOrThrow throws NegativeBookQuantityError', async () => {
+      const book = fakeBook();
+      // kinda hacky, but mocking this function is the simplest solution
+      prismaMock.order.findFirstOrThrow.mockRejectedValue(
+        new NegativeBookQuantityError(book),
+      );
+
+      expect(await completeOrder(1)).toEqual({
+        data: null,
+        error: {
+          book,
+          message: 'Attempting to set a negative quantity for Book',
+          name: NegativeBookQuantityError.name,
+        },
+        status: 400,
+      });
+    });
+
+    it('should return error when completeOrderOrThrow throws Error', async () => {
+      // kinda hacky, but mocking this function is the simplest solution
+      prismaMock.order.findFirstOrThrow.mockRejectedValue(
+        new Error('unrecognized error'),
+      );
+
+      expect(await completeOrder(1)).toEqual({
+        data: null,
+        status: 500,
+      });
+    });
+  });
+});

--- a/src/lib/actions/order.ts
+++ b/src/lib/actions/order.ts
@@ -1,0 +1,181 @@
+'use server';
+
+import { updateBookQuantity } from '@/lib/actions/book';
+import BadRequestError from '@/lib/errors/BadRequestError';
+import NegativeBookQuantityError from '@/lib/errors/NegativeBookQuantityError';
+import logger from '@/lib/logger';
+import { computeTax } from '@/lib/money';
+import prisma from '@/lib/prisma';
+import { HttpResponse } from '@/types/HttpResponse';
+import {
+  Order,
+  OrderItem,
+  OrderState,
+  Prisma,
+  ProductType,
+} from '@prisma/client';
+import { format } from 'date-fns';
+
+export async function createOrder(): Promise<Order> {
+  const { id } = await prisma.order.create({
+    data: {
+      orderOpenedDate: new Date(),
+      orderState: OrderState.OPEN,
+      subTotalInCents: 0,
+      taxInCents: 0,
+      totalInCents: 0,
+    },
+  });
+
+  // set a more readable UID
+  const orderUID = `${format(new Date(), 'yyMMddHHmmss')}-${id}`;
+  const createdOrder = await prisma.order.update({
+    data: { orderUID },
+    where: { id },
+  });
+
+  logger.trace('created order in DB: %j', createdOrder);
+
+  return createdOrder;
+}
+
+export async function recomputeOrderTotals({
+  orderItem,
+  tx,
+}: {
+  orderItem: OrderItem;
+  tx: Prisma.TransactionClient;
+}): Promise<void> {
+  const { orderId } = orderItem;
+
+  const order = await tx.order.findUniqueOrThrow({
+    where: { id: orderId },
+  });
+
+  const subTotalInCents = order.subTotalInCents + orderItem.totalPriceInCents;
+  const taxInCents = computeTax(subTotalInCents);
+  const totalInCents = subTotalInCents + taxInCents;
+
+  await tx.order.update({
+    data: {
+      subTotalInCents,
+      taxInCents,
+      totalInCents,
+    },
+    where: { id: orderId },
+  });
+}
+
+export async function completeOrderOrThrow(
+  orderId: Order['id'],
+): Promise<Order> {
+  const order = await prisma.order.findFirstOrThrow({
+    include: { orderItems: true },
+    where: { id: orderId },
+  });
+
+  if (order.orderState !== OrderState.OPEN) {
+    throw new BadRequestError('Order state must be in OPEN state to complete');
+  }
+
+  const { orderItems } = order;
+
+  // condense all the book updates by book ID
+  const bookUpdates = orderItems.reduce(
+    (acc, item) => {
+      if (item.productType !== ProductType.BOOK || item.bookId === null) {
+        logger.warn(
+          'non-book product type encountered, skipping order item: %j',
+          item,
+        );
+        return acc;
+      }
+
+      const match = acc.find((i) => i.id === item.bookId);
+      if (match) {
+        match.decreaseQuantity -= item.quantity;
+      } else {
+        acc.push({
+          decreaseQuantity: -item.quantity,
+          id: item.bookId,
+        });
+      }
+      return acc;
+    },
+    [] as Array<{ id: number; decreaseQuantity: number }>,
+  );
+
+  return prisma.$transaction(
+    async (tx) => {
+      logger.trace('updating books for %d order items...', orderItems.length);
+      await Promise.all(
+        bookUpdates.map((update) =>
+          updateBookQuantity({
+            bookId: update.id,
+            quantityChange: update.decreaseQuantity,
+            tx,
+          }),
+        ),
+      );
+
+      logger.trace(
+        'book updates successful, performing transaction, orderId: %s',
+        orderId,
+      );
+      // TODO here we'd actually perform the transaction
+
+      logger.trace(
+        'transaction successful, marking order paid, orderId: %s',
+        orderId,
+      );
+      const order = await tx.order.update({
+        data: {
+          orderClosedDate: new Date(),
+          orderState: OrderState.PAID,
+        },
+        where: { id: orderId },
+      });
+
+      logger.trace('order marked as paid and closed!');
+      return order;
+    },
+    {
+      isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+    },
+  );
+}
+
+export async function completeOrder(
+  orderId: Order['id'],
+): Promise<
+  HttpResponse<Order | null, BadRequestError | NegativeBookQuantityError>
+> {
+  try {
+    const order = await completeOrderOrThrow(orderId);
+
+    return {
+      data: order,
+      status: 200,
+    };
+  } catch (err: unknown) {
+    if (
+      err instanceof BadRequestError ||
+      err instanceof NegativeBookQuantityError
+    ) {
+      return {
+        data: null,
+        error: {
+          ...err,
+          message: err.message,
+          name: err.name,
+        },
+        status: 400,
+      };
+    }
+
+    return {
+      data: null,
+      status: 500,
+    };
+  }
+}

--- a/src/lib/errors/BadRequestError.ts
+++ b/src/lib/errors/BadRequestError.ts
@@ -1,0 +1,6 @@
+export default class BadRequestError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'BadRequestError';
+  }
+}

--- a/src/lib/fakes/order-item.ts
+++ b/src/lib/fakes/order-item.ts
@@ -1,0 +1,24 @@
+import { fakeCreatedAtUpdatedAt } from '@/lib/fakes/created-at-updated-at';
+import { convertDollarsToCents } from '@/lib/money';
+import { faker } from '@faker-js/faker';
+import { OrderItem, ProductType } from '@prisma/client';
+
+export default function fakeOrderItem(): OrderItem {
+  const productPriceInCents = convertDollarsToCents(
+    faker.commerce.price({ max: 50, min: 2 }),
+  );
+  const quantity =
+    Math.random() > 0.3 ? 1 : faker.number.int({ max: 10, min: 1 });
+  const totalPriceInCents = productPriceInCents * quantity;
+
+  return {
+    ...fakeCreatedAtUpdatedAt(),
+    bookId: faker.number.int(),
+    id: faker.number.int(),
+    orderId: faker.number.int(),
+    productPriceInCents,
+    productType: ProductType.BOOK,
+    quantity,
+    totalPriceInCents,
+  };
+}

--- a/src/lib/fakes/order.ts
+++ b/src/lib/fakes/order.ts
@@ -1,0 +1,24 @@
+import { fakeCreatedAtUpdatedAt } from '@/lib/fakes/created-at-updated-at';
+import { computeTax, convertDollarsToCents } from '@/lib/money';
+import { faker } from '@faker-js/faker';
+import { Order, OrderState } from '@prisma/client';
+
+export function fakeOrder(orderState: OrderState = OrderState.OPEN): Order {
+  const subTotalInCents = convertDollarsToCents(
+    faker.commerce.price({ max: 50, min: 2 }),
+  );
+  const taxInCents = computeTax(subTotalInCents);
+  const totalInCents = subTotalInCents + taxInCents;
+
+  return {
+    ...fakeCreatedAtUpdatedAt(),
+    id: faker.number.int(),
+    orderClosedDate: null,
+    orderOpenedDate: faker.date.past(),
+    orderState,
+    orderUID: faker.number.int().toString(),
+    subTotalInCents,
+    taxInCents,
+    totalInCents,
+  };
+}

--- a/src/types/HttpResponse.ts
+++ b/src/types/HttpResponse.ts
@@ -1,0 +1,5 @@
+export type HttpResponse<DataType, ErrorType extends Error> = {
+  data: DataType;
+  error?: ErrorType;
+  status: number;
+};

--- a/src/types/OrderItemCreateInput.ts
+++ b/src/types/OrderItemCreateInput.ts
@@ -1,0 +1,7 @@
+import { OrderItem } from '@prisma/client';
+
+type OrderItemCreateInput = Omit<
+  OrderItem,
+  'id' | 'createdAt' | 'updatedAt' | 'productPriceInCents' | 'totalPriceInCents'
+>;
+export default OrderItemCreateInput;


### PR DESCRIPTION
- Add actions to create and manage orders
- Setup a new pattern for Next.js server actions to return an `HttpResponse` when we need additional detail from the client. Since these are HTTP calls in the end, we can't just throw an error to send that information to the client. Instead we must encode that in the "response". So separate out the `completeOrderAndThrow` from `completeOrder` to use the latter to return the error rather than throwing it. We can then read that error on the client and perform the next steps.
- Add fakes for order and order item.
- Set the timezone within the test environment to UTC for consistent test results.