### PR TITLE
feat: Orders and Order page

### DIFF
--- a/src/app/invoices/[id]/InvoiceDescription.tsx
+++ b/src/app/invoices/[id]/InvoiceDescription.tsx
@@ -1,5 +1,6 @@
 import { discountPercentageToDisplayString } from '@/lib/money';
 import InvoiceHydrated from '@/types/InvoiceHydrated';
+import { NotepadTextIcon } from 'lucide-react';
 
 export default function InvoiceDescription({
   invoice,
@@ -13,36 +14,35 @@ export default function InvoiceDescription({
       data-testid="invoice-description"
     >
       <div className="flex flex-col">
-        <div className="font-bold" data-testid="vendor-name">
-          {vendor.name}
+        <div className="font-bold flex gap-2 items-center">
+          <NotepadTextIcon /> Invoice Details
         </div>
-        <div className="grid grid-cols-2 gap-0">
-          <div>
-            <div>Discount:</div>
-          </div>
+        <div data-testid="vendor-name">{vendor.name}</div>
+        <div className="grid grid-cols-2">
+          <div>Discount:</div>
           <div className="text-right" data-testid="discount-percentage">
-            <div>
-              {discountPercentageToDisplayString(vendor.discountPercentage)}
-            </div>
+            {discountPercentageToDisplayString(vendor.discountPercentage)}
           </div>
         </div>
       </div>
       <div>
-        <div className="grid grid-cols-2 gap-1">
-          <div>
-            <div>Invoice Number:</div>
-            <div>Invoice Date:</div>
-            {invoice.isCompleted && <div>Received:</div>}
+        <div className="grid grid-cols-2">
+          <div>Invoice Number:</div>
+          <div className="text-right" data-testid="invoice-number">
+            {invoice.invoiceNumber}
           </div>
-          <div className="text-right">
-            <div data-testid="invoice-number">{invoice.invoiceNumber}</div>
-            <div data-testid="invoice-date">
-              {invoice.invoiceDate.toLocaleDateString()}
-            </div>
-            {invoice.isCompleted && (
-              <div>{invoice.dateReceived?.toLocaleDateString()}</div>
-            )}
+          <div>Invoice Date:</div>
+          <div className="text-right" data-testid="invoice-date">
+            {invoice.invoiceDate.toLocaleDateString()}
           </div>
+          {invoice.isCompleted && (
+            <>
+              <div>Received:</div>
+              <div className="text-right">
+                {invoice.dateReceived?.toLocaleDateString()}
+              </div>
+            </>
+          )}
         </div>
       </div>
     </div>

--- a/src/app/orders/[uid]/OrderDescription.tsx
+++ b/src/app/orders/[uid]/OrderDescription.tsx
@@ -1,0 +1,32 @@
+import OrderHydrated from '@/types/OrderHydrated';
+import { GiftIcon } from 'lucide-react';
+
+export default function OrderDescription({ order }: { order: OrderHydrated }) {
+  return (
+    <div className="flex w-full justify-between text-lg">
+      <div className="flex flex-col">
+        <div className="font-bold flex gap-2 items-center">
+          <GiftIcon /> Order Details
+        </div>
+        <div className="flex gap-3">
+          <div>
+            <div>Number:</div>
+          </div>
+          <div>
+            <div>{order.orderUID}</div>
+          </div>
+        </div>
+      </div>
+      <div>
+        <div className="grid grid-cols-2">
+          <div>State:</div>
+          <div className="text-right">{order.orderState}</div>
+          <div>Date:</div>
+          <div className="text-right">
+            {order.orderOpenedDate.toLocaleDateString()}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/orders/[uid]/OrderTotal.tsx
+++ b/src/app/orders/[uid]/OrderTotal.tsx
@@ -1,0 +1,21 @@
+import Dollars from '@/components/Dollars';
+import OrderHydrated from '@/types/OrderHydrated';
+
+export default function OrderTotal({ order }: { order: OrderHydrated }) {
+  return (
+    <div className="grid grid-cols-2 gap-2">
+      <div>Subtotal:</div>
+      <div className="text-right">
+        <Dollars amountInCents={order.subTotalInCents} />
+      </div>
+      <div>Tax:</div>
+      <div className="text-right">
+        <Dollars amountInCents={order.taxInCents} />
+      </div>
+      <div className="font-bold text-lg">Total:</div>
+      <div className="font-bold text-lg text-right">
+        <Dollars amountInCents={order.totalInCents} />
+      </div>
+    </div>
+  );
+}

--- a/src/app/orders/[uid]/page.tsx
+++ b/src/app/orders/[uid]/page.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import OrderDescription from '@/app/orders/[uid]/OrderDescription';
+import OrderTotal from '@/app/orders/[uid]/OrderTotal';
+import {
+  Breadcrumbs,
+  BreadcrumbsHome,
+  BreadcrumbsDivider,
+  BreadcrumbsLink,
+  BreadcrumbsText,
+} from '@/components/Breadcrumbs';
+import OrderItemsTable from '@/components/order-item/OrderItemsTable';
+import { LoadingSpinner } from '@/components/ui/loading-spinner';
+import { getOrder } from '@/lib/actions/order';
+import { getOrderItems } from '@/lib/actions/order-item';
+import OrderHydrated from '@/types/OrderHydrated';
+import OrderItemHydrated from '@/types/OrderItemHydrated';
+import { useCallback, useEffect, useState } from 'react';
+
+export default function OrderPage({ params }: { params: { uid: string } }) {
+  const [order, setOrder] = useState<OrderHydrated | null>();
+  const [orderItems, setOrderItems] =
+    useState<Array<OrderItemHydrated> | null>();
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+
+  const orderUID = params.uid;
+
+  // Delay the loading animation a tiny amount to avoid screen flicker for quick connections (localhost)
+  const setDelayedLoading = useCallback(() => {
+    const timeout = setTimeout(() => setIsLoading(true), 100);
+    return () => {
+      setIsLoading(false);
+      clearTimeout(timeout);
+    };
+  }, []);
+
+  const loadOrder = useCallback(async () => {
+    const doneLoading = setDelayedLoading();
+    const order = await getOrder(orderUID);
+    setOrder(order);
+    doneLoading();
+  }, [orderUID, setDelayedLoading]);
+
+  const loadOrderItems = useCallback(async () => {
+    const doneLoading = setDelayedLoading();
+    // TODO handle pagination
+    const { orderItems } = await getOrderItems({
+      orderUID,
+      paginationQuery: {
+        first: 100,
+      },
+    });
+    setOrderItems(orderItems);
+    doneLoading();
+  }, [orderUID, setDelayedLoading]);
+
+  useEffect(() => {
+    loadOrder();
+    loadOrderItems();
+  }, [loadOrder, loadOrderItems]);
+
+  if (!order) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <Breadcrumbs>
+        <BreadcrumbsHome />
+        <BreadcrumbsDivider />
+        <BreadcrumbsLink href="/orders">Orders</BreadcrumbsLink>
+        <BreadcrumbsDivider />
+        <BreadcrumbsText>{order.orderUID}</BreadcrumbsText>
+      </Breadcrumbs>
+
+      <OrderDescription order={order} />
+
+      <hr className="my-8 mx-8 bg-slate-300" />
+
+      <div className="mt-4">
+        <OrderItemsTable
+          orderItems={orderItems || []}
+          isLoading={!orderItems || isLoading}
+        />
+      </div>
+
+      <div className="flex justify-end mt-4">
+        <OrderTotal order={order} />
+      </div>
+    </>
+  );
+}

--- a/src/app/orders/page.tsx
+++ b/src/app/orders/page.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import {
+  Breadcrumbs,
+  BreadcrumbsDivider,
+  BreadcrumbsHome,
+  BreadcrumbsText,
+} from '@/components/Breadcrumbs';
+import OrdersTable from '@/components/order/OrdersTable';
+import { Button } from '@/components/ui/button';
+import { getOrders } from '@/lib/actions/order';
+import OrderHydrated from '@/types/OrderHydrated';
+import { usePathname, useRouter } from 'next/navigation';
+import { useCallback, useEffect, useState } from 'react';
+
+export default function OrdersPage() {
+  const [orders, setOrders] = useState<Array<OrderHydrated> | null>();
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const pathname = usePathname();
+  const router = useRouter();
+
+  // Delay the loading animation a tiny amount to avoid screen flicker for quick connections (localhost)
+  const setDelayedLoading = useCallback(() => {
+    const timeout = setTimeout(() => setIsLoading(true), 50);
+    return () => {
+      setIsLoading(false);
+      clearTimeout(timeout);
+    };
+  }, []);
+
+  const loadOrders = useCallback(async () => {
+    const doneLoading = setDelayedLoading();
+    // TODO handle pagination
+    const { orders } = await getOrders({
+      paginationQuery: {
+        first: 100,
+      },
+    });
+    setOrders(orders);
+    doneLoading();
+  }, [setDelayedLoading]);
+
+  useEffect(() => {
+    loadOrders();
+  }, [loadOrders]);
+
+  return (
+    <>
+      <Breadcrumbs>
+        <BreadcrumbsHome />
+        <BreadcrumbsDivider />
+        <BreadcrumbsText>Orders</BreadcrumbsText>
+      </Breadcrumbs>
+
+      <h1 className="mt-8">Orders</h1>
+      <div className="flex w-full justify-end mb-4">
+        <Button variant="secondary">New Order</Button>
+      </div>
+
+      <OrdersTable
+        orders={orders || []}
+        isLoading={!orders || isLoading}
+        onClick={(uid) => router.push(`${pathname}/${uid}`)}
+      />
+    </>
+  );
+}

--- a/src/components/NavMenu.tsx
+++ b/src/components/NavMenu.tsx
@@ -11,6 +11,7 @@ import {
   MagnifyingGlassIcon,
   CardStackIcon,
   ReaderIcon,
+  BackpackIcon,
 } from '@radix-ui/react-icons';
 import Link from 'next/link';
 
@@ -37,6 +38,14 @@ export default function NavMenu() {
             <div className="flex items-center w-full cursor-pointer">
               <ReaderIcon />
               <span className="pl-2">Invoices</span>
+            </div>
+          </DropdownMenuItem>
+        </Link>
+        <Link href="/orders">
+          <DropdownMenuItem>
+            <div className="flex items-center w-full cursor-pointer">
+              <BackpackIcon />
+              <span className="pl-2">Orders</span>
             </div>
           </DropdownMenuItem>
         </Link>


### PR DESCRIPTION
- Add page to display the Orders, linking to the Order page
- Add page to display a single Order, and components broken out within the page
- Update the `InvoiceDescription` component to both standardize the heading and also fix some CSS issues with grid
- Add the Orders page to the nav menu