### PR TITLE
fix: search includes multiple words

### DIFF
--- a/src/lib/actions/book.test.ts
+++ b/src/lib/actions/book.test.ts
@@ -287,6 +287,28 @@ describe('book actions', () => {
       });
       expect(result).toEqual([book1, book2, book3]);
     });
+
+    it('should process multiple words', async () => {
+      prismaMock.book.findMany.mockResolvedValue([book2]);
+
+      const result = await findBooksBySearchString('the other book');
+
+      expect(prismaMock.book.findMany).toHaveBeenCalledWith({
+        include: {
+          authors: true,
+          format: true,
+          genre: true,
+          publisher: true,
+        },
+        where: {
+          OR: [
+            { authors: { some: { name: { search: 'the & other & book' } } } },
+            { title: { search: 'the & other & book' } },
+          ],
+        },
+      });
+      expect(result).toEqual([book2]);
+    });
   });
 
   describe('getBook', () => {

--- a/src/lib/actions/book.ts
+++ b/src/lib/actions/book.ts
@@ -242,8 +242,9 @@ export async function getBooks({
 }
 
 export async function findBooksBySearchString(
-  search: string,
+  searchString: string,
 ): Promise<Array<BookHydrated>> {
+  const search = searchString.split(' ').join(' & ');
   const rawBooks = await prisma.book.findMany({
     include: {
       authors: true,


### PR DESCRIPTION
The current implementation fails for multiple words. To resolve, take the approach recommended in `https://github.com/prisma/prisma/issues/8939` and join the words with `&`.