### PR TITLE
chore: refactor order with items

### DIFF
--- a/src/app/orders/[uid]/OrderDescription.tsx
+++ b/src/app/orders/[uid]/OrderDescription.tsx
@@ -1,7 +1,7 @@
-import OrderHydrated from '@/types/OrderHydrated';
+import { Order } from '@prisma/client';
 import { GiftIcon } from 'lucide-react';
 
-export default function OrderDescription({ order }: { order: OrderHydrated }) {
+export default function OrderDescription({ order }: { order: Order }) {
   return (
     <div className="flex w-full justify-between text-lg">
       <div className="flex flex-col">

--- a/src/app/orders/[uid]/OrderTotal.tsx
+++ b/src/app/orders/[uid]/OrderTotal.tsx
@@ -1,7 +1,7 @@
 import Dollars from '@/components/Dollars';
-import OrderHydrated from '@/types/OrderHydrated';
+import { Order } from '@prisma/client';
 
-export default function OrderTotal({ order }: { order: OrderHydrated }) {
+export default function OrderTotal({ order }: { order: Order }) {
   return (
     <div className="grid grid-cols-2 gap-2">
       <div>Subtotal:</div>

--- a/src/app/orders/[uid]/page.tsx
+++ b/src/app/orders/[uid]/page.tsx
@@ -11,53 +11,23 @@ import {
 } from '@/components/Breadcrumbs';
 import OrderItemsTable from '@/components/order-item/OrderItemsTable';
 import { LoadingSpinner } from '@/components/ui/loading-spinner';
-import { getOrder } from '@/lib/actions/order';
-import { getOrderItems } from '@/lib/actions/order-item';
-import OrderHydrated from '@/types/OrderHydrated';
-import OrderItemHydrated from '@/types/OrderItemHydrated';
+import { getOrderWithItems } from '@/lib/actions/order';
+import OrderWithItemsHydrated from '@/types/OrderWithItemsHydrated';
 import { useCallback, useEffect, useState } from 'react';
 
 export default function OrderPage({ params }: { params: { uid: string } }) {
-  const [order, setOrder] = useState<OrderHydrated | null>();
-  const [orderItems, setOrderItems] =
-    useState<Array<OrderItemHydrated> | null>();
-  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [order, setOrder] = useState<OrderWithItemsHydrated | null>();
 
   const orderUID = params.uid;
 
-  // Delay the loading animation a tiny amount to avoid screen flicker for quick connections (localhost)
-  const setDelayedLoading = useCallback(() => {
-    const timeout = setTimeout(() => setIsLoading(true), 100);
-    return () => {
-      setIsLoading(false);
-      clearTimeout(timeout);
-    };
-  }, []);
-
   const loadOrder = useCallback(async () => {
-    const doneLoading = setDelayedLoading();
-    const order = await getOrder(orderUID);
+    const order = await getOrderWithItems(orderUID);
     setOrder(order);
-    doneLoading();
-  }, [orderUID, setDelayedLoading]);
-
-  const loadOrderItems = useCallback(async () => {
-    const doneLoading = setDelayedLoading();
-    // TODO handle pagination
-    const { orderItems } = await getOrderItems({
-      orderUID,
-      paginationQuery: {
-        first: 100,
-      },
-    });
-    setOrderItems(orderItems);
-    doneLoading();
-  }, [orderUID, setDelayedLoading]);
+  }, [orderUID]);
 
   useEffect(() => {
     loadOrder();
-    loadOrderItems();
-  }, [loadOrder, loadOrderItems]);
+  }, [loadOrder]);
 
   if (!order) {
     return (
@@ -82,10 +52,7 @@ export default function OrderPage({ params }: { params: { uid: string } }) {
       <hr className="my-8 mx-8 bg-slate-300" />
 
       <div className="mt-4">
-        <OrderItemsTable
-          orderItems={orderItems || []}
-          isLoading={!orderItems || isLoading}
-        />
+        <OrderItemsTable orderItems={order.orderItems} />
       </div>
 
       <div className="flex justify-end mt-4">

--- a/src/lib/actions/order-item.test.ts
+++ b/src/lib/actions/order-item.test.ts
@@ -1,18 +1,14 @@
-import { createOrderItem, getOrderItems } from '@/lib/actions/order-item';
-import { fakeOrderItem, fakeOrderItemHydrated } from '@/lib/fakes/order-item';
+import { createOrderItem } from '@/lib/actions/order-item';
+import { fakeOrderItem } from '@/lib/fakes/order-item';
 import { prismaMock } from '../../../test-setup/prisma-mock.setup';
 import { fakeBook } from '@/lib/fakes/book';
 import { fakeOrder } from '@/lib/fakes/order';
 import { computeTax } from '@/lib/money';
 import { ProductType } from '@prisma/client';
-import { buildPaginationRequest } from '@/lib/pagination';
 
 describe('order item actions', () => {
   const order1 = fakeOrder();
   const orderItem1 = fakeOrderItem();
-  const orderItemHydrated1 = fakeOrderItemHydrated();
-  const orderItemHydrated2 = fakeOrderItemHydrated();
-  const orderItemHydrated3 = fakeOrderItemHydrated();
   const book1 = fakeBook();
 
   describe('createOrderItem', () => {
@@ -65,125 +61,6 @@ describe('order item actions', () => {
       ).rejects.toThrowErrorMatchingInlineSnapshot(
         `"bookId required as input at this time"`,
       );
-    });
-  });
-
-  describe('getOrderItems', () => {
-    it('should get order items when provided with default input', async () => {
-      prismaMock.orderItem.findMany.mockResolvedValue([
-        orderItemHydrated1,
-        orderItemHydrated2,
-        orderItemHydrated3,
-      ]);
-
-      const result = await getOrderItems({});
-
-      expect(prismaMock.orderItem.findMany).toHaveBeenCalledWith({
-        ...buildPaginationRequest({}),
-        include: {
-          book: {
-            include: {
-              authors: true,
-              format: true,
-              genre: true,
-              publisher: true,
-            },
-          },
-        },
-        orderBy: { createdAt: 'desc' },
-        where: { order: { orderUID: undefined } },
-      });
-      expect(result).toEqual({
-        orderItems: [
-          orderItemHydrated1,
-          orderItemHydrated2,
-          orderItemHydrated3,
-        ],
-        pageInfo: {
-          endCursor: orderItemHydrated3.id.toString(),
-          hasNextPage: false,
-          hasPreviousPage: false,
-          startCursor: orderItemHydrated1.id.toString(),
-        },
-      });
-    });
-
-    it('should get orders when provided with pagination query input', async () => {
-      prismaMock.orderItem.findMany.mockResolvedValue([
-        orderItemHydrated2,
-        orderItemHydrated3,
-      ]);
-
-      const result = await getOrderItems({
-        paginationQuery: {
-          after: '1',
-          first: 2,
-        },
-      });
-
-      expect(result).toEqual({
-        orderItems: [orderItemHydrated2, orderItemHydrated3],
-        pageInfo: {
-          endCursor: orderItemHydrated3.id.toString(),
-          hasNextPage: false,
-          hasPreviousPage: true,
-          startCursor: orderItemHydrated2.id.toString(),
-        },
-      });
-    });
-
-    it('should pass correct values to prisma when provided with orderId', async () => {
-      prismaMock.orderItem.findMany.mockResolvedValue([]);
-
-      await getOrderItems({ orderUID: 'uid123' });
-
-      expect(prismaMock.orderItem.findMany).toHaveBeenCalledWith({
-        ...buildPaginationRequest({}),
-        include: {
-          book: {
-            include: {
-              authors: true,
-              format: true,
-              genre: true,
-              publisher: true,
-            },
-          },
-        },
-        orderBy: { createdAt: 'desc' },
-        where: { order: { orderUID: 'uid123' } },
-      });
-    });
-
-    it('should process non-book product type order items', async () => {
-      prismaMock.orderItem.findMany.mockResolvedValue([
-        orderItemHydrated1,
-        orderItemHydrated2,
-        {
-          ...orderItemHydrated3,
-          productType: 'foo' as ProductType,
-        },
-      ]);
-
-      const result = await getOrderItems({});
-
-      expect(result).toEqual({
-        orderItems: [
-          orderItemHydrated1,
-          orderItemHydrated2,
-          {
-            ...orderItemHydrated3,
-            book: undefined,
-            bookId: null,
-            productType: 'foo',
-          },
-        ],
-        pageInfo: {
-          endCursor: orderItemHydrated3.id.toString(),
-          hasNextPage: false,
-          hasPreviousPage: false,
-          startCursor: orderItemHydrated1.id.toString(),
-        },
-      });
     });
   });
 });

--- a/src/lib/actions/order-item.ts
+++ b/src/lib/actions/order-item.ts
@@ -2,16 +2,8 @@
 
 import { recomputeOrderTotals } from '@/lib/actions/order';
 import logger from '@/lib/logger';
-import {
-  buildPaginationRequest,
-  buildPaginationResponse,
-} from '@/lib/pagination';
 import prisma from '@/lib/prisma';
-import { serializeBookSource } from '@/lib/serializers/book-source';
 import OrderItemCreateInput from '@/types/OrderItemCreateInput';
-import OrderItemHydrated from '@/types/OrderItemHydrated';
-import PageInfo from '@/types/PageInfo';
-import PaginationQuery from '@/types/PaginationQuery';
 import { OrderItem, Prisma, ProductType } from '@prisma/client';
 
 export async function createOrderItem(
@@ -57,71 +49,4 @@ export async function createOrderItem(
       isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
     },
   );
-}
-
-export interface GetOrderItemsParams {
-  paginationQuery?: PaginationQuery;
-  orderUID?: string;
-}
-
-export interface GetOrderItemsResult {
-  orderItems: Array<OrderItemHydrated>;
-  pageInfo: PageInfo;
-}
-
-export async function getOrderItems({
-  paginationQuery,
-  orderUID,
-}: GetOrderItemsParams): Promise<GetOrderItemsResult> {
-  const paginationRequest = buildPaginationRequest({ paginationQuery });
-
-  const rawItems = await prisma.orderItem.findMany({
-    ...paginationRequest,
-    include: {
-      book: {
-        include: {
-          authors: true,
-          format: true,
-          genre: true,
-          publisher: true,
-        },
-      },
-    },
-    orderBy: { createdAt: 'desc' },
-    where: { order: { orderUID } },
-  });
-
-  const items = rawItems.map((item) => {
-    if (item.productType !== ProductType.BOOK) {
-      // we have no other product types at this time, so this should not happen
-      logger.warn('non-book product type encountered: %j', item);
-      return {
-        ...item,
-        book: undefined,
-        bookId: null,
-      };
-    }
-
-    // we can assume the book is available based on code above
-    const itemBook = item.book!;
-
-    return {
-      ...item,
-      book: {
-        ...itemBook,
-        publisher: serializeBookSource(itemBook.publisher),
-      },
-    };
-  });
-
-  const { items: orderItems, pageInfo } =
-    buildPaginationResponse<OrderItemHydrated>({
-      items,
-      paginationQuery,
-    });
-
-  return {
-    orderItems,
-    pageInfo,
-  };
 }

--- a/src/types/OrderWithItemsHydrated.ts
+++ b/src/types/OrderWithItemsHydrated.ts
@@ -1,0 +1,7 @@
+import OrderItemHydrated from '@/types/OrderItemHydrated';
+import { Order } from '@prisma/client';
+
+type OrderWithItemsHydrated = Order & {
+  orderItems: Array<OrderItemHydrated>;
+};
+export default OrderWithItemsHydrated;


### PR DESCRIPTION
- The order page was loading both the order and the associated order items. We can make 1 SQL query to load both, simplifying the logic. We're not paginating the order items, but the list should always be small and we can add pagination later if this changes.
- Remove the now-unneeded getOrder and getOrderItems