### PR TITLE
feat: tweaks to create order actions

### DIFF
--- a/prisma/seed/fake.ts
+++ b/prisma/seed/fake.ts
@@ -218,7 +218,7 @@ async function generateOrder(props: GenerateOrderProps) {
   } else {
     await createOrderItem({
       bookId: booksInRandomOrder[0].id,
-      orderId: order.id,
+      orderUID: order.orderUID,
       productType: ProductType.BOOK,
       quantity: 1,
     });
@@ -226,7 +226,7 @@ async function generateOrder(props: GenerateOrderProps) {
     if (books.length > 1) {
       await createOrderItem({
         bookId: booksInRandomOrder[1].id,
-        orderId: order.id,
+        orderUID: order.orderUID,
         productType: ProductType.BOOK,
         quantity: 1,
       });

--- a/src/lib/actions/order-item.test.ts
+++ b/src/lib/actions/order-item.test.ts
@@ -21,7 +21,10 @@ describe('order item actions', () => {
       orderItem1.bookId = book1.id;
       prismaMock.orderItem.create.mockResolvedValue(orderItem1);
 
-      await createOrderItem(orderItem1);
+      await createOrderItem({
+        ...orderItem1,
+        orderUID: order1.orderUID,
+      });
 
       expect(prismaMock.orderItem.create).toHaveBeenCalledWith({
         data: {
@@ -29,7 +32,7 @@ describe('order item actions', () => {
             connect: { id: book1.id },
           },
           order: {
-            connect: { id: order1.id },
+            connect: { orderUID: order1.orderUID },
           },
           productPriceInCents: book1.priceInCents,
           productType: ProductType.BOOK,
@@ -57,6 +60,7 @@ describe('order item actions', () => {
         createOrderItem({
           ...orderItem1,
           bookId: null,
+          orderUID: order1.orderUID,
         }),
       ).rejects.toThrowErrorMatchingInlineSnapshot(
         `"bookId required as input at this time"`,

--- a/src/lib/actions/order-item.ts
+++ b/src/lib/actions/order-item.ts
@@ -9,7 +9,7 @@ import { OrderItem, Prisma, ProductType } from '@prisma/client';
 export async function createOrderItem(
   orderItem: OrderItemCreateInput,
 ): Promise<OrderItem> {
-  const { bookId, orderId, quantity } = orderItem;
+  const { bookId, orderUID, quantity } = orderItem;
 
   // we only handle order items of product type Book at this time
   const productType = ProductType.BOOK;
@@ -30,7 +30,7 @@ export async function createOrderItem(
             connect: { id: bookId },
           },
           order: {
-            connect: { id: orderId },
+            connect: { orderUID },
           },
           productPriceInCents,
           productType,

--- a/src/lib/actions/order.test.ts
+++ b/src/lib/actions/order.test.ts
@@ -47,7 +47,7 @@ describe('order action', () => {
       prismaMock.order.create.mockResolvedValue(order1);
       prismaMock.order.update.mockResolvedValue(order1);
 
-      await createOrder();
+      const result = await createOrder();
 
       expect(prismaMock.order.create).toHaveBeenCalledWith({
         data: {
@@ -61,6 +61,11 @@ describe('order action', () => {
       expect(prismaMock.order.update).toHaveBeenCalledWith({
         data: { orderUID: `210203121314-${order1.id}` },
         where: { id: order1.id },
+      });
+
+      expect(result).toEqual({
+        ...order1,
+        orderItems: [],
       });
     });
   });

--- a/src/lib/actions/order.ts
+++ b/src/lib/actions/order.ts
@@ -25,7 +25,7 @@ import {
 } from '@prisma/client';
 import { format } from 'date-fns';
 
-export async function createOrder(): Promise<Order> {
+export async function createOrder(): Promise<OrderWithItemsHydrated> {
   const { id } = await prisma.order.create({
     data: {
       orderOpenedDate: new Date(),
@@ -45,7 +45,10 @@ export async function createOrder(): Promise<Order> {
 
   logger.trace('created order in DB: %j', createdOrder);
 
-  return createdOrder;
+  return {
+    ...createdOrder,
+    orderItems: [],
+  };
 }
 
 export async function recomputeOrderTotals({

--- a/src/types/OrderItemCreateInput.ts
+++ b/src/types/OrderItemCreateInput.ts
@@ -2,6 +2,13 @@ import { OrderItem } from '@prisma/client';
 
 type OrderItemCreateInput = Omit<
   OrderItem,
-  'id' | 'createdAt' | 'updatedAt' | 'productPriceInCents' | 'totalPriceInCents'
->;
+  | 'id'
+  | 'createdAt'
+  | 'updatedAt'
+  | 'orderId'
+  | 'productPriceInCents'
+  | 'totalPriceInCents'
+> & {
+  orderUID: string;
+};
 export default OrderItemCreateInput;


### PR DESCRIPTION
- `createOrder` should return a full `OrderWithItemsHydrated` for consistent order retrieval.
- `createOrderItem` should accept an `orderUID` rather than `orderId` for consistency in how we handle order lookups