### PR TITLE
feat: checkout resume/delete/complete

### DIFF
--- a/src/app/orders/[uid]/OpenOrderActions.tsx
+++ b/src/app/orders/[uid]/OpenOrderActions.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+
+export default function OpenOrderActions({
+  onCheckout,
+  onDelete,
+}: {
+  onCheckout: () => void;
+  onDelete: () => void;
+}) {
+  return (
+    <div className="flex gap-4 justify-end">
+      <Button variant="secondary" onClick={onCheckout}>
+        Resume Checkout
+      </Button>
+      <Button variant="destructive" onClick={onDelete}>
+        Delete Order
+      </Button>
+    </div>
+  );
+}


### PR DESCRIPTION
- Add `OpenOrderActions` to resume and delete an existing order (that is in the OPEN state)
- Add code to support "completing" an order to the checkout page
- set the orderUID query param if not set, and clear order when not supplied (this allows for navigation to /checkout to clear the order)