### PR TITLE
fix: small fixes for checkmark component

### DIFF
--- a/src/components/stories/ui/checkmark.stories.tsx
+++ b/src/components/stories/ui/checkmark.stories.tsx
@@ -16,10 +16,10 @@ export const Large: Story = {
   args: { size: 'large' },
 };
 
-export const XLarge: Story = {
+export const ExtraLarge: Story = {
   args: { size: 'xLarge' },
 };
 
-export const Blue: Story = {
+export const DifferentColor: Story = {
   args: { color: '#0044ff', size: 'xLarge' },
 };

--- a/src/components/ui/checkmark.tsx
+++ b/src/components/ui/checkmark.tsx
@@ -41,39 +41,41 @@ const checkmarkVariants = cva('', {
 });
 
 export interface CheckmarkProps
-  extends React.HTMLAttributes<HTMLElement>,
+  extends React.HTMLAttributes<HTMLDivElement>,
     VariantProps<typeof checkmarkVariants> {
-  color: string;
+  color?: string;
 }
 
 function Checkmark({
   className,
   color = '#00cc88',
   size = 'large',
+  ...props
 }: CheckmarkProps) {
-  let pixelSize, fillSize: number;
+  let pixelSize, strokeWidth: number;
   switch (size) {
     case 'small':
       pixelSize = 20;
-      fillSize = 3;
+      strokeWidth = 2;
       break;
     case 'xLarge':
       pixelSize = 200;
-      fillSize = 10;
+      strokeWidth = 10;
       break;
     case 'large':
     default:
       pixelSize = 100;
-      fillSize = 5;
+      strokeWidth = 5;
       break;
   }
 
   return (
     <div
       className={cn(
-        `w-[${pixelSize}px] h-[${pixelSize}px] stroke-[${fillSize}] fill-transparent`,
+        `w-[${pixelSize}px] h-[${pixelSize}px] fill-transparent`,
         className,
       )}
+      {...props}
     >
       <motion.svg
         width={pixelSize}
@@ -88,6 +90,7 @@ function Checkmark({
           cy={pixelSize / 2}
           r={pixelSize * 0.4}
           stroke={color}
+          strokeWidth={strokeWidth}
           variants={draw}
           custom={1.2}
         />
@@ -97,6 +100,7 @@ function Checkmark({
           x2={pixelSize * 0.455}
           y2={pixelSize * 0.675}
           stroke={color}
+          strokeWidth={strokeWidth}
           variants={draw}
           custom={0}
         />
@@ -106,6 +110,7 @@ function Checkmark({
           x2={pixelSize * 0.7}
           y2={pixelSize * 0.32}
           stroke={color}
+          strokeWidth={strokeWidth}
           variants={draw}
           custom={0.5}
         />


### PR DESCRIPTION
- change the color prop to optional
- directly set the stroke width on the SVG rather than relying on the CSS. This was having issues without this change...
- expose all props for the parent div, just in case