### PR TITLE
feat: search handles ISBN number input

### DIFF
--- a/src/lib/actions/book.test.ts
+++ b/src/lib/actions/book.test.ts
@@ -309,6 +309,25 @@ describe('book actions', () => {
       });
       expect(result).toEqual([book2]);
     });
+
+    it('should process ISBN13', async () => {
+      prismaMock.book.findMany.mockResolvedValue([book2]);
+
+      const result = await findBooksBySearchString('9780765376671');
+
+      expect(prismaMock.book.findMany).toHaveBeenCalledWith({
+        include: {
+          authors: true,
+          format: true,
+          genre: true,
+          publisher: true,
+        },
+        where: {
+          OR: [{ isbn13: { equals: 9780765376671 } }],
+        },
+      });
+      expect(result).toEqual([book2]);
+    });
   });
 
   describe('getBook', () => {


### PR DESCRIPTION
We're expanding the book search capability to support a number as input (in the string), and if so, assume it's an ISBN13 value. We're at the point where we may want to consider making this search input a bit more specific to what it's looking for (perhaps an object rather than string?), but it works for now.

If the input is a number, query for a matching `isbn13` value. Add a test to demo.