### PR TITLE
feat: process transaction page

### DIFF
--- a/src/app/checkout/[uid]/process-transaction/page.tsx
+++ b/src/app/checkout/[uid]/process-transaction/page.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import Dollars from '@/components/Dollars';
+import { Button } from '@/components/ui/button';
+import { Checkmark } from '@/components/ui/checkmark';
+import { LoadingCircle } from '@/components/ui/loading-circle';
+import { LoadingSpinner } from '@/components/ui/loading-spinner';
+import { getOrderWithItems } from '@/lib/actions/order';
+import OrderWithItemsHydrated from '@/types/OrderWithItemsHydrated';
+import Link from 'next/link';
+import { useCallback, useEffect, useState } from 'react';
+
+export default function CheckoutProcessTransactionPage({
+  params,
+}: {
+  params: { uid: string };
+}) {
+  const [order, setOrder] = useState<OrderWithItemsHydrated | null>();
+  const [isComplete, setIsComplete] = useState(false);
+
+  const orderUID = params.uid;
+
+  const loadOrder = useCallback(async () => {
+    const order = await getOrderWithItems(orderUID);
+    setOrder(order);
+  }, [orderUID]);
+
+  useEffect(() => {
+    loadOrder();
+  }, [loadOrder]);
+
+  if (!order) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  // TODO actually complete the order
+
+  return (
+    <div className="flex flex-col items-center gap-4 mt-[150px] text-xl text-center">
+      <div>
+        <p>Order {order.orderUID}</p>
+        <p>
+          Total:{' '}
+          <span className="font-bold">
+            <Dollars amountInCents={order.totalInCents} />
+          </span>
+        </p>
+      </div>
+      <div className="w-[200px] h-[200px]">
+        {!isComplete ? (
+          <LoadingCircle
+            size="xLarge"
+            // TODO delete me -- added for demo purposes
+            onClick={() => setIsComplete((v) => !v)}
+          />
+        ) : (
+          <Checkmark
+            size="xLarge"
+            // TODO delete me -- added for demo purposes
+            onClick={() => setIsComplete((v) => !v)}
+          />
+        )}
+      </div>
+      <div>
+        {!isComplete ? (
+          <p>Awaiting transaction...</p>
+        ) : (
+          <p>Checkout complete!</p>
+        )}
+      </div>
+      <div className="w-[180px]">
+        {!isComplete ? (
+          <Button className="w-full" variant="destructive">
+            Cancel transaction
+          </Button>
+        ) : (
+          <Link href="/checkout">
+            <Button className="w-full" variant="default">
+              Start New Checkout
+            </Button>
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/checkout/page.tsx
+++ b/src/app/checkout/page.tsx
@@ -12,16 +12,13 @@ import Search from '@/components/search/Search';
 import { Button } from '@/components/ui/button';
 import { LoadingSpinner } from '@/components/ui/loading-spinner';
 import { getBook } from '@/lib/actions/book';
-import {
-  completeOrder,
-  createOrder,
-  getOrderWithItems,
-} from '@/lib/actions/order';
+import { createOrder, getOrderWithItems } from '@/lib/actions/order';
 import { createOrderItem } from '@/lib/actions/order-item';
 import OrderWithItemsHydrated from '@/types/OrderWithItemsHydrated';
 import { ProductType } from '@prisma/client';
 import clsx from 'clsx';
 import { motion, AnimatePresence } from 'framer-motion';
+import Link from 'next/link';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
@@ -95,21 +92,6 @@ export default function CheckoutPage() {
     [order, pathname, router, searchParams],
   );
 
-  const onComplete = useCallback(async () => {
-    if (!order) {
-      return;
-    }
-
-    const response = await completeOrder(order.orderUID);
-    if (response.status === 200) {
-      // TODO should we do more on success here?
-      router.push('/checkout');
-    } else {
-      // TODO handle errors
-      console.error(response);
-    }
-  }, [order, router]);
-
   if (orderUID && !order) {
     return (
       <div className="flex h-full items-center justify-center">
@@ -160,7 +142,9 @@ export default function CheckoutPage() {
                 transition={{ delay: 0.2 }}
                 exit={{ opacity: 0 }}
               >
-                <Button onClick={onComplete}>Complete Order</Button>
+                <Link href={`/checkout/${order.orderUID}/process-transaction`}>
+                  <Button>Complete Order</Button>
+                </Link>
               </motion.div>
             )}
           </div>


### PR DESCRIPTION
Add page which is responsible for moving an order from OPEN to PAID. This will most likely involve creating a transaction in the background, and waiting for the transaction to complete (the customer to make the purchase). While we wait, show a loading animation to the admin and provide a way to cancel the transaction if needed.

For now, this is mostly just for show.

---

https://github.com/dylants/bookstore/assets/1596740/ed31a8b4-86ca-495f-bcce-7b83f6363d1b

