### PR TITLE
perf: Use Link in DataTable

### DIFF
--- a/src/app/invoices/page.tsx
+++ b/src/app/invoices/page.tsx
@@ -12,7 +12,7 @@ import { getBookSources } from '@/lib/actions/book-source';
 import { createInvoice, getInvoices } from '@/lib/actions/invoice';
 import BookSourceSerialized from '@/types/BookSourceSerialized';
 import InvoiceHydrated from '@/types/InvoiceHydrated';
-import { usePathname, useRouter } from 'next/navigation';
+import { usePathname } from 'next/navigation';
 import { useCallback, useEffect, useState } from 'react';
 
 export default function InvoicesPage() {
@@ -20,7 +20,6 @@ export default function InvoicesPage() {
   const [vendors, setVendors] = useState<Array<BookSourceSerialized>>([]);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const pathname = usePathname();
-  const router = useRouter();
 
   const loadVendors = useCallback(async () => {
     // TODO handle pagination
@@ -83,7 +82,7 @@ export default function InvoicesPage() {
       <InvoicesTable
         invoices={invoices || []}
         isLoading={!invoices || isLoading}
-        onClick={(id) => router.push(`${pathname}/${id}`)}
+        linkPathname={pathname}
       />
     </>
   );

--- a/src/app/orders/page.tsx
+++ b/src/app/orders/page.tsx
@@ -9,14 +9,13 @@ import {
 import OrdersTable from '@/components/order/OrdersTable';
 import { getOrders } from '@/lib/actions/order';
 import OrderHydrated from '@/types/OrderHydrated';
-import { usePathname, useRouter } from 'next/navigation';
+import { usePathname } from 'next/navigation';
 import { useCallback, useEffect, useState } from 'react';
 
 export default function OrdersPage() {
   const [orders, setOrders] = useState<Array<OrderHydrated> | null>();
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const pathname = usePathname();
-  const router = useRouter();
 
   // Delay the loading animation a tiny amount to avoid screen flicker for quick connections (localhost)
   const setDelayedLoading = useCallback(() => {
@@ -57,7 +56,7 @@ export default function OrdersPage() {
         <OrdersTable
           orders={orders || []}
           isLoading={!orders || isLoading}
-          onClick={(uid) => router.push(`${pathname}/${uid}`)}
+          linkPathname={pathname}
         />
       </div>
     </>

--- a/src/components/invoice/InvoicesTable.tsx
+++ b/src/components/invoice/InvoicesTable.tsx
@@ -57,19 +57,19 @@ const columns: ColumnDef<InvoiceHydrated>[] = [
 export default function InvoicesTable({
   invoices,
   isLoading,
-  onClick,
+  linkPathname,
 }: {
   invoices: InvoiceHydrated[];
   isLoading?: boolean;
-  onClick?: (id: number) => void;
+  linkPathname: string;
 }) {
   return (
     <DataTable
       columns={columns}
       data={invoices}
       isLoading={isLoading}
+      linkPathname={linkPathname}
       noDataText="No Invoices found"
-      onClick={(id) => onClick?.(id as number)}
     />
   );
 }

--- a/src/components/order/OrdersTable.tsx
+++ b/src/components/order/OrdersTable.tsx
@@ -74,11 +74,11 @@ const columns: ColumnDef<OrderHydrated>[] = [
 export default function OrdersTable({
   orders,
   isLoading,
-  onClick,
+  linkPathname,
 }: {
   orders: OrderHydrated[];
   isLoading?: boolean;
-  onClick?: (id: string) => void;
+  linkPathname: string;
 }) {
   return (
     <DataTable
@@ -86,8 +86,8 @@ export default function OrdersTable({
       data={orders}
       idFieldName={'orderUID'}
       isLoading={isLoading}
+      linkPathname={linkPathname}
       noDataText="No Orders found"
-      onClick={(uid) => onClick?.(uid as string)}
     />
   );
 }

--- a/src/components/stories/invoice/InvoicesTable.stories.tsx
+++ b/src/components/stories/invoice/InvoicesTable.stories.tsx
@@ -21,13 +21,7 @@ export const Default: Story = {
 
     return (
       <div>
-        <InvoicesTable
-          invoices={invoices}
-          onClick={(id) => {
-            const invoice = invoices.find((i) => i.id === id);
-            console.log(`clicked invoice number ${invoice?.invoiceNumber}`);
-          }}
-        />
+        <InvoicesTable invoices={invoices} linkPathname="#" />
       </div>
     );
   },

--- a/src/components/stories/order/OrdersTable.stories.tsx
+++ b/src/components/stories/order/OrdersTable.stories.tsx
@@ -26,12 +26,7 @@ export const Default: Story = {
 
     return (
       <div>
-        <OrdersTable
-          orders={orders}
-          onClick={(uid) => {
-            console.log(`clicked order UID ${uid}`);
-          }}
-        />
+        <OrdersTable orders={orders} linkPathname="#" />
       </div>
     );
   },

--- a/src/components/stories/table/DataTable.stories.tsx
+++ b/src/components/stories/table/DataTable.stories.tsx
@@ -89,11 +89,7 @@ export const Clickable: Story = {
   render: () => {
     return (
       <div>
-        <DataTable
-          columns={columns}
-          data={data}
-          onClick={(id) => console.log(`clicked ${id}`)}
-        />
+        <DataTable columns={columns} data={data} linkPathname="#" />
       </div>
     );
   },
@@ -114,7 +110,7 @@ export const ClickableWithIdFieldName: Story = {
           columns={columns}
           data={clickableData}
           idFieldName={'uid'}
-          onClick={(id) => console.log(`clicked ${id}`)}
+          linkPathname="#"
         />
       </div>
     );

--- a/src/components/table/DataTable.tsx
+++ b/src/components/table/DataTable.tsx
@@ -18,6 +18,7 @@ import {
   useReactTable,
 } from '@tanstack/react-table';
 import clsx from 'clsx';
+import Link from 'next/link';
 import { useState } from 'react';
 
 export type DataTableProps<TData, TValue> = {
@@ -25,8 +26,8 @@ export type DataTableProps<TData, TValue> = {
   data: TData[];
   idFieldName?: string;
   isLoading?: boolean;
+  linkPathname?: string;
   noDataText?: string;
-  onClick?: (id: unknown) => void;
 };
 
 export default function DataTable<TData, TValue>({
@@ -34,8 +35,8 @@ export default function DataTable<TData, TValue>({
   data,
   idFieldName = 'id',
   isLoading,
+  linkPathname,
   noDataText = 'No items',
-  onClick,
 }: DataTableProps<TData, TValue>) {
   const [sorting, setSorting] = useState<SortingState>([]);
   const table = useReactTable({
@@ -69,15 +70,21 @@ export default function DataTable<TData, TValue>({
     <>
       {table.getRowModel().rows?.length ? (
         table.getRowModel().rows.map((row) => (
-          <TableRow
-            key={row.id}
-            data-state={row.getIsSelected() && 'selected'}
-            onClick={() => onClick?.(row.id)}
-            className={clsx(onClick && 'cursor-pointer')}
-          >
+          <TableRow key={row.id} data-state={row.getIsSelected() && 'selected'}>
             {row.getVisibleCells().map((cell) => (
-              <TableCell key={cell.id}>
-                {flexRender(cell.column.columnDef.cell, cell.getContext())}
+              <TableCell key={cell.id} className={clsx(linkPathname && 'p-0')}>
+                {linkPathname ? (
+                  <Link
+                    href={`${linkPathname}/${row.id}`}
+                    className="block p-2"
+                  >
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </Link>
+                ) : (
+                  <>
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </>
+                )}
               </TableCell>
             ))}
           </TableRow>


### PR DESCRIPTION
- Instead of bubbling up the onClick function to the callers, wrap the table cell contents in a Link if requested. This does two things: little performance boost b/c we're using Next.js Links, and users see the elements of the table as links with hrefs.
- Update all callers based on the changes made