### PR TITLE
feat: Add pending transaction order state

### DIFF
--- a/prisma/migrations/20240321223424_pending_transaction/migration.sql
+++ b/prisma/migrations/20240321223424_pending_transaction/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "OrderState" ADD VALUE 'PENDING_TRANSACTION';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -138,6 +138,7 @@ model Order {
 enum OrderState {
   // "open" states
   OPEN
+  PENDING_TRANSACTION
 
   // "closed" states
   PAID


### PR DESCRIPTION
- Add an additional OrderState to encompass when the user wishes to pay for the order, but has not yet paid. In this state we shall "reserve" the products for them while we wait for the transaction to finalize, and the state to move to paid.