### PR TITLE
feat: order actions: pending and cancel

### DIFF
--- a/prisma/seed/fake.ts
+++ b/prisma/seed/fake.ts
@@ -18,7 +18,10 @@ import {
 import retry from 'async-retry';
 import _ from 'lodash';
 import generateCoreSeeds from './core';
-import { completeOrderOrThrow, createOrder } from '@/lib/actions/order';
+import {
+  createOrder,
+  moveOrderToPendingTransactionOrThrow,
+} from '@/lib/actions/order';
 import { createOrderItem } from '@/lib/actions/order-item';
 
 // ***********************************************************
@@ -234,7 +237,8 @@ async function generateOrder(props: GenerateOrderProps) {
   }
 
   if (completeOrder) {
-    await completeOrderOrThrow(order.orderUID);
+    // TODO we need to fully complete here once the code is available
+    await moveOrderToPendingTransactionOrThrow(order.orderUID);
   }
 }
 


### PR DESCRIPTION
- Change the existing function `completeOrder` to instead be `moveOrderToPendingTransaction` as it will move an order from OPEN to PENDING_TRANSACTION. In doing this it will subtract the inventory for the books, verifying we have the inventory available.
- Add the inverse function, named `cancelPendingTransaction` which will move the order from PENDING_TRANSACTION to OPEN. This will add the inventory back, "releasing" it from hold.
- Update seeds, but we do not yet have fully completed order ability.