### PR TITLE
feat: increase default delay in order state sync

### DIFF
--- a/src/lib/hooks/useSyncOrderState.test.tsx
+++ b/src/lib/hooks/useSyncOrderState.test.tsx
@@ -2,7 +2,9 @@
  * @jest-environment jsdom
  */
 
-import useSyncOrderState from '@/lib/hooks/useSyncOrderState';
+import useSyncOrderState, {
+  DEFAULT_DELAY,
+} from '@/lib/hooks/useSyncOrderState';
 import { OrderState } from '@prisma/client';
 import { act, renderHook } from '@testing-library/react';
 
@@ -38,7 +40,7 @@ describe('useSyncOrderState', () => {
     // we see the updated state
     mockGetOrderState.mockReturnValue(OrderState.OPEN);
     await act(async () => {
-      jest.advanceTimersByTime(2000);
+      jest.advanceTimersByTime(DEFAULT_DELAY);
     });
     expect(result.current.getOrderState()).toEqual(OrderState.OPEN);
 
@@ -46,7 +48,7 @@ describe('useSyncOrderState', () => {
     // we see the updated state
     mockGetOrderState.mockReturnValue(OrderState.PAID);
     await act(async () => {
-      jest.advanceTimersByTime(2000);
+      jest.advanceTimersByTime(DEFAULT_DELAY);
     });
     expect(result.current.getOrderState()).toEqual(OrderState.PAID);
 
@@ -55,7 +57,7 @@ describe('useSyncOrderState', () => {
     unsubscribe();
     mockGetOrderState.mockReturnValue(OrderState.OPEN);
     await act(async () => {
-      jest.advanceTimersByTime(2000);
+      jest.advanceTimersByTime(DEFAULT_DELAY);
     });
     expect(result.current.getOrderState()).toEqual(OrderState.PAID);
   });

--- a/src/lib/hooks/useSyncOrderState.tsx
+++ b/src/lib/hooks/useSyncOrderState.tsx
@@ -4,18 +4,20 @@ import { getOrderState } from '@/lib/actions/order';
 import { OrderState } from '@prisma/client';
 import { useCallback, useState } from 'react';
 
-type UseSyncOrderStateProps = {
+export const DEFAULT_DELAY = 3000;
+
+export type UseSyncOrderStateProps = {
   delay?: number;
   orderUID: string;
 };
 
-type UseSyncOrderStateResult = {
+export type UseSyncOrderStateResult = {
   getOrderState: () => OrderState | null;
   subscribe: () => () => void;
 };
 
 export default function useSyncOrderState({
-  delay = 2000,
+  delay = DEFAULT_DELAY,
   orderUID,
 }: UseSyncOrderStateProps): UseSyncOrderStateResult {
   const [orderState, setOrderState] = useState<OrderState | null>(null);


### PR DESCRIPTION
During some manual testing with slow internet speeds, the poll would not be complete before the next one started. To adjust for this, increase the delay by 1 second.