### PR TITLE
feat: Transaction with Square migration

### DIFF
--- a/prisma/migrations/20240326193610_transaction_with_square/migration.sql
+++ b/prisma/migrations/20240326193610_transaction_with_square/migration.sql
@@ -1,0 +1,45 @@
+-- CreateEnum
+CREATE TYPE "TransactionStatus" AS ENUM ('PENDING', 'CANCELLED', 'COMPLETE');
+
+-- CreateEnum
+CREATE TYPE "TransactionType" AS ENUM ('SQUARE_CHECKOUT');
+
+-- CreateTable
+CREATE TABLE "Transaction" (
+    "id" SERIAL NOT NULL,
+    "createdAt" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMPTZ(3),
+    "orderUID" TEXT NOT NULL,
+    "amountInCents" INTEGER NOT NULL,
+    "transactionUID" TEXT NOT NULL,
+    "status" "TransactionStatus" NOT NULL,
+    "transactionType" "TransactionType" NOT NULL,
+
+    CONSTRAINT "Transaction_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "SquareCheckout" (
+    "id" SERIAL NOT NULL,
+    "createdAt" TIMESTAMPTZ(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMPTZ(3),
+    "checkoutId" TEXT NOT NULL,
+    "amountInCents" INTEGER NOT NULL,
+    "status" TEXT NOT NULL,
+    "paymentType" TEXT,
+    "transactionUID" TEXT NOT NULL,
+
+    CONSTRAINT "SquareCheckout_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Transaction_transactionUID_key" ON "Transaction"("transactionUID");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SquareCheckout_transactionUID_key" ON "SquareCheckout"("transactionUID");
+
+-- AddForeignKey
+ALTER TABLE "Transaction" ADD CONSTRAINT "Transaction_orderUID_fkey" FOREIGN KEY ("orderUID") REFERENCES "Order"("orderUID") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SquareCheckout" ADD CONSTRAINT "SquareCheckout_transactionUID_fkey" FOREIGN KEY ("transactionUID") REFERENCES "Transaction"("transactionUID") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -133,6 +133,8 @@ model Order {
   totalInCents    Int
 
   orderItems OrderItem[]
+
+  transactions Transaction[]
 }
 
 enum OrderState {
@@ -160,4 +162,48 @@ model OrderItem {
 
   book   Book? @relation(fields: [bookId], references: [id])
   bookId Int?
+}
+
+model Transaction {
+  id        Int       @id @default(autoincrement())
+  createdAt DateTime  @default(now()) @db.Timestamptz(3)
+  updatedAt DateTime? @updatedAt @db.Timestamptz(3)
+
+  order    Order  @relation(fields: [orderUID], references: [orderUID], onDelete: Cascade)
+  orderUID String
+
+  amountInCents  Int
+  transactionUID String @unique @default(uuid())
+
+  status TransactionStatus
+
+  transactionType TransactionType
+  squareCheckout  SquareCheckout?
+}
+
+enum TransactionStatus {
+  // initial state
+  PENDING
+
+  // terminal states
+  CANCELLED
+  COMPLETE
+}
+
+enum TransactionType {
+  SQUARE_CHECKOUT
+}
+
+model SquareCheckout {
+  id        Int       @id @default(autoincrement())
+  createdAt DateTime  @default(now()) @db.Timestamptz(3)
+  updatedAt DateTime? @updatedAt @db.Timestamptz(3)
+
+  checkoutId    String
+  amountInCents Int
+  status        String
+  paymentType   String?
+
+  transaction    Transaction @relation(fields: [transactionUID], references: [transactionUID], onDelete: Cascade)
+  transactionUID String      @unique
 }


### PR DESCRIPTION
- Add Transaction and SquareCheckout database tables
- Include the TransactionType to differentiate future types of transactions, but for now, we only support Square
- Multiple Transactions exists within an Order, to account for cancelled transactions. Also will support future split transactions (which won't be initially supported).