### PR TITLE
feat: transaction actions

### DIFF
--- a/src/lib/actions/transaction.test.ts
+++ b/src/lib/actions/transaction.test.ts
@@ -1,0 +1,208 @@
+import { fakeOrder } from '@/lib/fakes/order';
+import { prismaMock } from '../../../test-setup/prisma-mock.setup';
+import { fakeTransaction } from '@/lib/fakes/transaction';
+import {
+  createTransactionOrThrow,
+  syncTransactionStatusOrThrow,
+} from '@/lib/actions/transaction';
+import {
+  Transaction,
+  TransactionStatus,
+  TransactionType,
+} from '@prisma/client';
+import {
+  SQUARE_TERMINAL_CHECKOUT_STATUS_CANCELLED,
+  SQUARE_TERMINAL_CHECKOUT_STATUS_COMPLETED,
+} from '@/lib/square-terminal-checkout';
+
+const mockCreateSquareTerminalCheckout = jest.fn();
+const mockGetSquareTerminalCheckout = jest.fn();
+jest.mock('../square-terminal-checkout', () => ({
+  ...jest.requireActual('../square-terminal-checkout'),
+  createSquareTerminalCheckout: (...args: unknown[]) =>
+    mockCreateSquareTerminalCheckout(...args),
+  getSquareTerminalCheckout: (...args: unknown[]) =>
+    mockGetSquareTerminalCheckout(...args),
+}));
+
+describe('transaction actions', () => {
+  const order = fakeOrder();
+  const transaction = fakeTransaction();
+
+  beforeEach(() => {
+    mockCreateSquareTerminalCheckout.mockReset();
+    mockGetSquareTerminalCheckout.mockReset();
+
+    prismaMock.$transaction.mockImplementation((cb) => cb(prismaMock));
+  });
+
+  describe('createTransactionOrThrow', () => {
+    it('should create the transaction', async () => {
+      prismaMock.order.findFirstOrThrow.mockResolvedValue(order);
+      prismaMock.transaction.create.mockResolvedValue(transaction);
+      mockCreateSquareTerminalCheckout.mockResolvedValue({ foo: 'bar' });
+      prismaMock.transaction.update.mockResolvedValue(transaction);
+
+      const createdTransaction = await createTransactionOrThrow(order.orderUID);
+
+      expect(prismaMock.transaction.create).toHaveBeenCalledWith({
+        data: {
+          amountInCents: order.totalInCents,
+          order: { connect: { orderUID: order.orderUID } },
+          status: TransactionStatus.PENDING,
+          transactionType: TransactionType.SQUARE_CHECKOUT,
+        },
+      });
+      expect(mockCreateSquareTerminalCheckout).toHaveBeenCalledWith({
+        transaction,
+      });
+      expect(prismaMock.transaction.update).toHaveBeenCalledWith({
+        data: {
+          squareCheckout: {
+            create: {
+              foo: 'bar',
+            },
+          },
+        },
+        where: { id: transaction.id },
+      });
+
+      expect(createdTransaction).toEqual(transaction);
+    });
+  });
+
+  describe('syncTransactionStatusOrThrow', () => {
+    const checkoutId = 'checkoutId123';
+    const transactionWithCheckout: Transaction = {
+      ...transaction,
+      squareCheckout: {
+        checkoutId,
+      },
+    } as Transaction;
+
+    it('should process correctly on completed', async () => {
+      prismaMock.transaction.findUniqueOrThrow.mockResolvedValue(
+        transactionWithCheckout,
+      );
+      mockGetSquareTerminalCheckout.mockResolvedValue({
+        checkoutId,
+        paymentType: 'CARD_PRESENT',
+        status: SQUARE_TERMINAL_CHECKOUT_STATUS_COMPLETED,
+      });
+      prismaMock.transaction.update.mockResolvedValue(transaction);
+
+      const syncedTransaction = await syncTransactionStatusOrThrow(
+        transactionWithCheckout.transactionUID,
+      );
+
+      expect(mockGetSquareTerminalCheckout).toHaveBeenCalledWith({
+        checkoutId,
+      });
+      expect(prismaMock.transaction.update).toHaveBeenCalledWith({
+        data: {
+          squareCheckout: {
+            update: {
+              checkoutId,
+              paymentType: 'CARD_PRESENT',
+              status: SQUARE_TERMINAL_CHECKOUT_STATUS_COMPLETED,
+            },
+          },
+          status: TransactionStatus.COMPLETE,
+        },
+        where: { transactionUID: transactionWithCheckout.transactionUID },
+      });
+      expect(syncedTransaction).toEqual(transaction);
+    });
+
+    it('should process correctly on cancelled', async () => {
+      prismaMock.transaction.findUniqueOrThrow.mockResolvedValue(
+        transactionWithCheckout,
+      );
+      mockGetSquareTerminalCheckout.mockResolvedValue({
+        checkoutId,
+        paymentType: 'CARD_PRESENT',
+        status: SQUARE_TERMINAL_CHECKOUT_STATUS_CANCELLED,
+      });
+      prismaMock.transaction.update.mockResolvedValue(transaction);
+
+      const syncedTransaction = await syncTransactionStatusOrThrow(
+        transactionWithCheckout.transactionUID,
+      );
+
+      expect(mockGetSquareTerminalCheckout).toHaveBeenCalledWith({
+        checkoutId,
+      });
+      expect(prismaMock.transaction.update).toHaveBeenCalledWith({
+        data: {
+          squareCheckout: {
+            update: {
+              checkoutId,
+              paymentType: 'CARD_PRESENT',
+              status: SQUARE_TERMINAL_CHECKOUT_STATUS_CANCELLED,
+            },
+          },
+          status: TransactionStatus.CANCELLED,
+        },
+        where: { transactionUID: transactionWithCheckout.transactionUID },
+      });
+      expect(syncedTransaction).toEqual(transaction);
+    });
+
+    it('should be a no-op on pending', async () => {
+      prismaMock.transaction.findUniqueOrThrow.mockResolvedValue(
+        transactionWithCheckout,
+      );
+      mockGetSquareTerminalCheckout.mockResolvedValue({
+        checkoutId,
+        paymentType: 'CARD_PRESENT',
+        status: 'PENDING',
+      });
+
+      const syncedTransaction = await syncTransactionStatusOrThrow(
+        transactionWithCheckout.transactionUID,
+      );
+
+      expect(mockGetSquareTerminalCheckout).toHaveBeenCalledWith({
+        checkoutId,
+      });
+      expect(prismaMock.transaction.update).not.toHaveBeenCalledWith();
+      expect(syncedTransaction).toEqual(transactionWithCheckout);
+    });
+
+    it('should return transaction when transaction status is terminal', async () => {
+      prismaMock.transaction.findUniqueOrThrow.mockResolvedValue({
+        ...transactionWithCheckout,
+        status: TransactionStatus.CANCELLED,
+      });
+
+      const syncedTransaction = await syncTransactionStatusOrThrow(
+        transactionWithCheckout.transactionUID,
+      );
+
+      expect(mockGetSquareTerminalCheckout).not.toHaveBeenCalled();
+      expect(prismaMock.transaction.update).not.toHaveBeenCalledWith();
+      expect(syncedTransaction).toEqual({
+        ...transactionWithCheckout,
+        status: TransactionStatus.CANCELLED,
+      });
+    });
+
+    it('should throw error when transactionType is not Square checkout', async () => {
+      prismaMock.transaction.findUniqueOrThrow.mockResolvedValue({
+        ...transactionWithCheckout,
+        transactionType: 'foo' as TransactionType,
+      });
+
+      expect.assertions(2);
+      try {
+        await syncTransactionStatusOrThrow(
+          transactionWithCheckout.transactionUID,
+        );
+      } catch (err) {
+        expect(err instanceof Error).toBeTruthy();
+        const error: Error = err as Error;
+        expect(error.message).toEqual('Unsupported transactionType: foo');
+      }
+    });
+  });
+});

--- a/src/lib/actions/transaction.ts
+++ b/src/lib/actions/transaction.ts
@@ -1,0 +1,215 @@
+import {
+  SQUARE_TERMINAL_CHECKOUT_STATUS_CANCELLED,
+  SQUARE_TERMINAL_CHECKOUT_STATUS_COMPLETED,
+  createSquareTerminalCheckout,
+  getSquareTerminalCheckout,
+} from '@/lib/square-terminal-checkout';
+import logger from '@/lib/logger';
+import prisma from '@/lib/prisma';
+import {
+  Prisma,
+  SquareCheckout,
+  Transaction,
+  TransactionStatus,
+  TransactionType,
+} from '@prisma/client';
+
+export async function createTransactionOrThrow(
+  orderUID: string,
+): Promise<Transaction> {
+  return prisma.$transaction(
+    async (tx) => {
+      // TODO update the order to PENDING_TRANSACTION
+
+      const order = await tx.order.findFirstOrThrow({
+        where: { orderUID },
+      });
+
+      logger.trace('creating new Transaction for orderUID: %s', orderUID);
+      const transaction = await tx.transaction.create({
+        data: {
+          amountInCents: order.totalInCents,
+          order: { connect: { orderUID } },
+          status: TransactionStatus.PENDING,
+          transactionType: TransactionType.SQUARE_CHECKOUT,
+        },
+      });
+
+      const checkout = await createSquareTerminalCheckout({ transaction });
+
+      logger.trace(
+        'updating transaction to link to Square Checkout checkoutId: %s orderUID: %s',
+        checkout.checkoutId,
+        orderUID,
+      );
+      const updatedTransaction = await tx.transaction.update({
+        data: {
+          squareCheckout: {
+            create: {
+              ...checkout,
+            },
+          },
+        },
+        where: { id: transaction.id },
+      });
+
+      logger.trace(
+        'Transaction successfully created with Square Checkout transactionUID: %s for orderUID: %s',
+        transaction.transactionUID,
+        orderUID,
+      );
+      return updatedTransaction;
+    },
+    {
+      isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+    },
+  );
+}
+
+function isTransactionStatusTerminal(transactionStatus: TransactionStatus) {
+  return (
+    transactionStatus === TransactionStatus.CANCELLED ||
+    transactionStatus === TransactionStatus.COMPLETE
+  );
+}
+
+async function processCompletedCheckout({
+  checkout,
+  orderUID,
+  transactionUID,
+  tx,
+}: {
+  checkout: Partial<SquareCheckout>;
+  orderUID: string;
+  transactionUID: string;
+  tx: Prisma.TransactionClient;
+}): Promise<Transaction> {
+  // we don't support split payments at this time,
+  // so if the status is complete, the order is fully paid
+  logger.info(
+    'updating TransactionStatus to COMPLETE, marking order as PAID for transactionUID: %s orderUID: %s',
+    transactionUID,
+    orderUID,
+  );
+  const updatedTransaction = await tx.transaction.update({
+    data: {
+      squareCheckout: {
+        update: { ...checkout },
+      },
+      status: TransactionStatus.COMPLETE,
+    },
+    where: { transactionUID },
+  });
+
+  // TODO update the order to PAID
+
+  return updatedTransaction;
+}
+
+async function processCancelledCheckout({
+  checkout,
+  orderUID,
+  transactionUID,
+  tx,
+}: {
+  checkout: Partial<SquareCheckout>;
+  orderUID: string;
+  transactionUID: string;
+  tx: Prisma.TransactionClient;
+}): Promise<Transaction> {
+  logger.info(
+    'Updating TransactionStatus to CANCELLED, cancel order to pending transaction transactionUID: %s orderUID: %s',
+    transactionUID,
+    orderUID,
+  );
+  const updatedTransaction = await tx.transaction.update({
+    data: {
+      squareCheckout: {
+        update: { ...checkout },
+      },
+      status: TransactionStatus.CANCELLED,
+    },
+    where: { transactionUID },
+  });
+
+  // TODO update the order to OPEN
+
+  return updatedTransaction;
+}
+
+export async function syncTransactionStatusOrThrow(
+  transactionUID: Transaction['transactionUID'],
+): Promise<Transaction> {
+  return prisma.$transaction(
+    async (tx) => {
+      logger.trace(
+        'syncing transaction status for transactionUID: %s',
+        transactionUID,
+      );
+      const transaction = await tx.transaction.findUniqueOrThrow({
+        include: { squareCheckout: true },
+        where: { transactionUID },
+      });
+
+      const {
+        orderUID,
+        squareCheckout,
+        status: previousTransactionStatus,
+        transactionType,
+      } = transaction;
+
+      if (isTransactionStatusTerminal(previousTransactionStatus)) {
+        logger.info(
+          'requested to sync transaction status for transaction in terminal state, no updates for transactionUID: %s',
+          transactionUID,
+        );
+        return transaction;
+      }
+
+      // we only support Square checkout at this time
+      if (
+        transactionType !== TransactionType.SQUARE_CHECKOUT ||
+        !squareCheckout
+      ) {
+        logger.error(
+          'Unsupported transactionType %s for transactionUID: %s',
+          transactionType,
+          transactionUID,
+        );
+        throw new Error('Unsupported transactionType: ' + transactionType);
+      }
+
+      const { checkoutId } = squareCheckout;
+      const checkout = await getSquareTerminalCheckout({ checkoutId });
+
+      if (checkout.status === SQUARE_TERMINAL_CHECKOUT_STATUS_COMPLETED) {
+        return processCompletedCheckout({
+          checkout,
+          orderUID,
+          transactionUID,
+          tx,
+        });
+      } else if (
+        checkout.status === SQUARE_TERMINAL_CHECKOUT_STATUS_CANCELLED
+      ) {
+        return processCancelledCheckout({
+          checkout,
+          orderUID,
+          transactionUID,
+          tx,
+        });
+      } else {
+        // Other status options are: PENDING, IN_PROGRESS, CANCEL_REQUESTED
+        // https://developer.squareup.com/reference/square/objects/TerminalCheckout#definition__property-status
+        logger.info(
+          'square checkout still in pending status, no updates for transactionUID: %s',
+          transactionUID,
+        );
+        return transaction;
+      }
+    },
+    {
+      isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+    },
+  );
+}


### PR DESCRIPTION
- Add transaction actions to create transaction and sync the transaction status with the square checkout
- Include TODOs to refactor the order flow to run from the transaction rather than the order. So we'll create and cancel transactions rather than moving orders from the UI.