### PR TITLE
feat: create transaction moves order state

### DIFF
--- a/prisma/seed/fake.ts
+++ b/prisma/seed/fake.ts
@@ -18,10 +18,7 @@ import {
 import retry from 'async-retry';
 import _ from 'lodash';
 import generateCoreSeeds from './core';
-import {
-  createOrder,
-  moveOrderToPendingTransactionOrThrow,
-} from '@/lib/actions/order';
+import { createOrder } from '@/lib/actions/order';
 import { createOrderItem } from '@/lib/actions/order-item';
 
 // ***********************************************************
@@ -238,7 +235,6 @@ async function generateOrder(props: GenerateOrderProps) {
 
   if (completeOrder) {
     // TODO we need to fully complete here once the code is available
-    await moveOrderToPendingTransactionOrThrow(order.orderUID);
   }
 }
 

--- a/src/lib/actions/transaction.test.ts
+++ b/src/lib/actions/transaction.test.ts
@@ -35,6 +35,13 @@ jest.mock('../square-terminal-checkout', () => ({
     mockGetSquareTerminalCheckout(...args),
 }));
 
+const mockMoveOrderToPendingTransactionOrThrow = jest.fn();
+jest.mock('./order', () => ({
+  ...jest.requireActual('./order'),
+  moveOrderToPendingTransactionOrThrow: (...args: unknown[]) =>
+    mockMoveOrderToPendingTransactionOrThrow(...args),
+}));
+
 describe('transaction actions', () => {
   const order = fakeOrder();
   const transaction = fakeTransaction();
@@ -56,7 +63,7 @@ describe('transaction actions', () => {
 
   describe('createTransactionOrThrow', () => {
     it('should create the transaction', async () => {
-      prismaMock.order.findFirstOrThrow.mockResolvedValue(order);
+      mockMoveOrderToPendingTransactionOrThrow.mockResolvedValue(order);
       prismaMock.transaction.create.mockResolvedValue(transaction);
       mockCreateSquareTerminalCheckout.mockResolvedValue({ foo: 'bar' });
       prismaMock.transaction.update.mockResolvedValue(transaction);
@@ -91,7 +98,7 @@ describe('transaction actions', () => {
 
   describe('createTransaction', () => {
     it('should return the transaction when successful', async () => {
-      prismaMock.order.findFirstOrThrow.mockResolvedValue(order);
+      mockMoveOrderToPendingTransactionOrThrow.mockResolvedValue(order);
       prismaMock.transaction.create.mockResolvedValue(transaction);
       mockCreateSquareTerminalCheckout.mockResolvedValue({ foo: 'bar' });
       prismaMock.transaction.update.mockResolvedValue(transaction);
@@ -104,7 +111,7 @@ describe('transaction actions', () => {
 
     it('should return error when createTransactionOrThrow throws BadRequestError', async () => {
       // kinda hacky, but mocking this function is the simplest solution
-      prismaMock.order.findFirstOrThrow.mockRejectedValue(
+      mockMoveOrderToPendingTransactionOrThrow.mockRejectedValue(
         new BadRequestError('bad input'),
       );
 
@@ -121,7 +128,7 @@ describe('transaction actions', () => {
     it('should return error when createTransactionOrThrow throws NegativeBookQuantityError', async () => {
       const book = fakeBook();
       // kinda hacky, but mocking this function is the simplest solution
-      prismaMock.order.findFirstOrThrow.mockRejectedValue(
+      mockMoveOrderToPendingTransactionOrThrow.mockRejectedValue(
         new NegativeBookQuantityError(book),
       );
 
@@ -138,7 +145,7 @@ describe('transaction actions', () => {
 
     it('should return error when createTransactionOrThrow throws Error', async () => {
       // kinda hacky, but mocking this function is the simplest solution
-      prismaMock.order.findFirstOrThrow.mockRejectedValue(
+      mockMoveOrderToPendingTransactionOrThrow.mockRejectedValue(
         new Error('unrecognized error'),
       );
 

--- a/src/lib/actions/transaction.ts
+++ b/src/lib/actions/transaction.ts
@@ -18,16 +18,16 @@ import {
 import { HttpResponse } from '@/types/HttpResponse';
 import BadRequestError from '@/lib/errors/BadRequestError';
 import NegativeBookQuantityError from '@/lib/errors/NegativeBookQuantityError';
+import { moveOrderToPendingTransactionOrThrow } from '@/lib/actions/order';
 
 export async function createTransactionOrThrow(
   orderUID: Order['orderUID'],
 ): Promise<Transaction> {
   return prisma.$transaction(
     async (tx) => {
-      // TODO update the order to PENDING_TRANSACTION
-
-      const order = await tx.order.findFirstOrThrow({
-        where: { orderUID },
+      const order = await moveOrderToPendingTransactionOrThrow({
+        orderUID,
+        tx,
       });
 
       logger.trace('creating new Transaction for orderUID: %s', orderUID);


### PR DESCRIPTION
- The main part of this change was done in the transaction actions -- we're now moving the order to pending transaction status when we create a new transaction.
- With the above change, we no longer need the frontend to move the order, but instead, create the transaction. This removes the need for `moveOrderToPendingTransaction` as well.
- The page redirect does not yet work, but including that change in this PR would make it much larger, so will cover in a future PR.
- Also removing the "complete" order seeds for now, will revisit in the future.