### PR TITLE
feat: terminal transaction states move order

### DIFF
--- a/src/app/orders/[uid]/page.tsx
+++ b/src/app/orders/[uid]/page.tsx
@@ -12,11 +12,7 @@ import {
 import OrderItemsTable from '@/components/order-item/OrderItemsTable';
 import { Button } from '@/components/ui/button';
 import { LoadingSpinner } from '@/components/ui/loading-spinner';
-import {
-  cancelPendingTransaction,
-  deleteOrder,
-  getOrderWithItems,
-} from '@/lib/actions/order';
+import { deleteOrder, getOrderWithItems } from '@/lib/actions/order';
 import OrderWithItemsHydrated from '@/types/OrderWithItemsHydrated';
 import { OrderState } from '@prisma/client';
 import Link from 'next/link';
@@ -50,19 +46,6 @@ export default function OrderPage({ params }: { params: { uid: string } }) {
       setIsDeleting(false);
     }
   }, [orderUID, router]);
-
-  const [isCancelling, setIsCancelling] = useState(false);
-  const onCancel = useCallback(async () => {
-    setIsCancelling(true);
-    const response = await cancelPendingTransaction(orderUID);
-    if (response.status === 200) {
-      loadOrder();
-    } else {
-      // TODO handle errors
-      console.error(response.error);
-      setIsCancelling(false);
-    }
-  }, [loadOrder, orderUID]);
 
   if (!order) {
     return (
@@ -98,18 +81,6 @@ export default function OrderPage({ params }: { params: { uid: string } }) {
               Delete Order
             </Button>
           </div>
-        </div>
-      )}
-      {order.orderState === OrderState.PENDING_TRANSACTION && (
-        <div className="mt-4 flex justify-end">
-          <Button
-            variant="destructive"
-            isLoading={isCancelling}
-            onClick={onCancel}
-            className="w-[150px]"
-          >
-            Cancel Transaction
-          </Button>
         </div>
       )}
 

--- a/src/lib/actions/transaction.test.ts
+++ b/src/lib/actions/transaction.test.ts
@@ -35,9 +35,15 @@ jest.mock('../square-terminal-checkout', () => ({
     mockGetSquareTerminalCheckout(...args),
 }));
 
+const mockMoveOrderToOpenOrThrow = jest.fn();
+const mockMoveOrderToPaidOrThrow = jest.fn();
 const mockMoveOrderToPendingTransactionOrThrow = jest.fn();
 jest.mock('./order', () => ({
   ...jest.requireActual('./order'),
+  moveOrderToOpenOrThrow: (...args: unknown[]) =>
+    mockMoveOrderToOpenOrThrow(...args),
+  moveOrderToPaidOrThrow: (...args: unknown[]) =>
+    mockMoveOrderToPaidOrThrow(...args),
   moveOrderToPendingTransactionOrThrow: (...args: unknown[]) =>
     mockMoveOrderToPendingTransactionOrThrow(...args),
 }));
@@ -57,6 +63,10 @@ describe('transaction actions', () => {
     mockCancelSquareTerminalCheckout.mockReset();
     mockCreateSquareTerminalCheckout.mockReset();
     mockGetSquareTerminalCheckout.mockReset();
+
+    mockMoveOrderToOpenOrThrow.mockReset();
+    mockMoveOrderToPaidOrThrow.mockReset();
+    mockMoveOrderToPendingTransactionOrThrow.mockReset();
 
     prismaMock.$transaction.mockImplementation((cb) => cb(prismaMock));
   });
@@ -188,6 +198,8 @@ describe('transaction actions', () => {
         },
         where: { transactionUID: transactionWithCheckout.transactionUID },
       });
+      expect(mockMoveOrderToPaidOrThrow).toHaveBeenCalled();
+      expect(mockMoveOrderToOpenOrThrow).not.toHaveBeenCalled();
       expect(syncedTransaction).toEqual(transaction);
     });
 
@@ -222,6 +234,8 @@ describe('transaction actions', () => {
         },
         where: { transactionUID: transactionWithCheckout.transactionUID },
       });
+      expect(mockMoveOrderToPaidOrThrow).not.toHaveBeenCalled();
+      expect(mockMoveOrderToOpenOrThrow).toHaveBeenCalled();
       expect(syncedTransaction).toEqual(transaction);
     });
 


### PR DESCRIPTION
- update the transaction actions to move the order state when the transaction reaches a terminal state. If cancelled, move order back to open. If complete, move order to paid.
- change the frontend to call the transaction functions to cancel
- remove the cancel transaction from order page... we'll need a transaction list to choose which one to cancel.