### PR TITLE
feat: order cleanup + safe functions

### DIFF
--- a/src/app/orders/[uid]/page.tsx
+++ b/src/app/orders/[uid]/page.tsx
@@ -12,7 +12,8 @@ import {
 import OrderItemsTable from '@/components/order-item/OrderItemsTable';
 import { Button } from '@/components/ui/button';
 import { LoadingSpinner } from '@/components/ui/loading-spinner';
-import { deleteOrder, getOrderWithItems } from '@/lib/actions/order';
+import { getOrderWithItems } from '@/lib/actions/order';
+import { deleteOrderSafe } from '@/lib/actions/order-safe';
 import OrderWithItemsHydrated from '@/types/OrderWithItemsHydrated';
 import { OrderState } from '@prisma/client';
 import Link from 'next/link';
@@ -37,7 +38,7 @@ export default function OrderPage({ params }: { params: { uid: string } }) {
   const [isDeleting, setIsDeleting] = useState(false);
   const onDelete = useCallback(async () => {
     setIsDeleting(true);
-    const response = await deleteOrder(orderUID);
+    const response = await deleteOrderSafe(orderUID);
     if (response.status === 200) {
       router.push('/orders');
     } else {

--- a/src/lib/actions/order-safe.test.ts
+++ b/src/lib/actions/order-safe.test.ts
@@ -1,0 +1,45 @@
+import { deleteOrderSafe } from '@/lib/actions/order-safe';
+import BadRequestError from '@/lib/errors/BadRequestError';
+
+const mockDeleteOrder = jest.fn();
+jest.mock('./order', () => ({
+  ...jest.requireActual('./order'),
+  deleteOrder: (...args: unknown[]) => mockDeleteOrder(...args),
+}));
+
+describe('order safe actions', () => {
+  describe('deleteOrderSafe', () => {
+    beforeEach(() => {
+      mockDeleteOrder.mockReset();
+    });
+
+    it('should return 200 when successful', async () => {
+      expect(await deleteOrderSafe('1')).toEqual({
+        data: null,
+        status: 200,
+      });
+    });
+
+    it('should return error when deleteOrder throws BadRequestError', async () => {
+      mockDeleteOrder.mockRejectedValue(new BadRequestError('bad input'));
+
+      expect(await deleteOrderSafe('1')).toEqual({
+        data: null,
+        error: {
+          message: 'bad input',
+          name: BadRequestError.name,
+        },
+        status: 400,
+      });
+    });
+
+    it('should return error when deleteOrder throws Error', async () => {
+      mockDeleteOrder.mockRejectedValue(new Error('unrecognized error'));
+
+      expect(await deleteOrderSafe('1')).toEqual({
+        data: null,
+        status: 500,
+      });
+    });
+  });
+});

--- a/src/lib/actions/order-safe.ts
+++ b/src/lib/actions/order-safe.ts
@@ -1,0 +1,36 @@
+'use server';
+
+import { deleteOrder } from '@/lib/actions/order';
+import BadRequestError from '@/lib/errors/BadRequestError';
+import { HttpResponse } from '@/types/HttpResponse';
+import { Order } from '@prisma/client';
+
+export async function deleteOrderSafe(
+  orderUID: Order['orderUID'],
+): Promise<HttpResponse<null, BadRequestError>> {
+  try {
+    await deleteOrder(orderUID);
+
+    return {
+      data: null,
+      status: 200,
+    };
+  } catch (err: unknown) {
+    if (err instanceof BadRequestError) {
+      return {
+        data: null,
+        error: {
+          ...err,
+          message: err.message,
+          name: err.name,
+        },
+        status: 400,
+      };
+    }
+
+    return {
+      data: null,
+      status: 500,
+    };
+  }
+}

--- a/src/lib/actions/order.test.ts
+++ b/src/lib/actions/order.test.ts
@@ -2,9 +2,7 @@ import { prismaMock } from '../../../test-setup/prisma-mock.setup';
 import {
   createOrder,
   deleteOrder,
-  deleteOrderOrThrow,
   getOrder,
-  getOrderState,
   getOrderWithItems,
   getOrders,
   moveOrderToOpenOrThrow,
@@ -394,12 +392,12 @@ describe('order action', () => {
     });
   });
 
-  describe('deleteOrderOrThrow', () => {
+  describe('deleteOrder', () => {
     it('should delete the order', async () => {
       prismaMock.order.findFirstOrThrow.mockResolvedValue(order1);
       prismaMock.order.delete.mockResolvedValue(order1);
 
-      await deleteOrderOrThrow(order1.orderUID);
+      await deleteOrder(order1.orderUID);
 
       expect(prismaMock.order.findFirstOrThrow).toHaveBeenCalledWith({
         where: { orderUID: order1.orderUID },
@@ -419,7 +417,7 @@ describe('order action', () => {
 
       expect.assertions(2);
       try {
-        await deleteOrderOrThrow(order.orderUID);
+        await deleteOrder(order.orderUID);
       } catch (err) {
         expect(err instanceof BadRequestError).toBeTruthy();
         const error: BadRequestError = err as BadRequestError;
@@ -430,45 +428,6 @@ describe('order action', () => {
     });
   });
 
-  describe('deleteOrder', () => {
-    it('should return 200 when successful', async () => {
-      prismaMock.order.findFirstOrThrow.mockResolvedValue(order1);
-      prismaMock.order.delete.mockResolvedValue(order1);
-
-      expect(await deleteOrder('1')).toEqual({
-        data: null,
-        status: 200,
-      });
-    });
-
-    it('should return error when deleteOrderOrThrow throws BadRequestError', async () => {
-      // kinda hacky, but mocking this function is the simplest solution
-      prismaMock.order.findFirstOrThrow.mockRejectedValue(
-        new BadRequestError('bad input'),
-      );
-
-      expect(await deleteOrder('1')).toEqual({
-        data: null,
-        error: {
-          message: 'bad input',
-          name: BadRequestError.name,
-        },
-        status: 400,
-      });
-    });
-
-    it('should return error when deleteOrderOrThrow throws Error', async () => {
-      // kinda hacky, but mocking this function is the simplest solution
-      prismaMock.order.findFirstOrThrow.mockRejectedValue(
-        new Error('unrecognized error'),
-      );
-
-      expect(await deleteOrder('1')).toEqual({
-        data: null,
-        status: 500,
-      });
-    });
-  });
   describe('getOrders', () => {
     it('should get orders when provided with default input', async () => {
       prismaMock.order.findMany.mockResolvedValue([
@@ -631,20 +590,6 @@ describe('order action', () => {
     it('returns null when order does not exist', async () => {
       prismaMock.order.findUnique.mockResolvedValue(null);
       const result = await getOrder('uid123');
-      expect(result).toEqual(null);
-    });
-  });
-
-  describe('getOrderState', () => {
-    it('returns the order state when it exists', async () => {
-      prismaMock.order.findUnique.mockResolvedValue(order1);
-      const result = await getOrderState('uid123');
-      expect(result).toEqual(order1.orderState);
-    });
-
-    it('returns null when order does not exist', async () => {
-      prismaMock.order.findUnique.mockResolvedValue(null);
-      const result = await getOrderState('uid123');
       expect(result).toEqual(null);
     });
   });

--- a/src/lib/actions/order.ts
+++ b/src/lib/actions/order.ts
@@ -10,7 +10,6 @@ import {
 } from '@/lib/pagination';
 import prisma from '@/lib/prisma';
 import { serializeBookSource } from '@/lib/serializers/book-source';
-import { HttpResponse } from '@/types/HttpResponse';
 import OrderHydrated from '@/types/OrderHydrated';
 import OrderWithItemsHydrated from '@/types/OrderWithItemsHydrated';
 import PageInfo from '@/types/PageInfo';
@@ -226,7 +225,7 @@ export async function moveOrderToOpenOrThrow({
   return updatedOrder;
 }
 
-export async function deleteOrderOrThrow(orderUID: Order['orderUID']) {
+export async function deleteOrder(orderUID: Order['orderUID']) {
   logger.trace('request to delete order, orderUID: %s', orderUID);
   const order = await prisma.order.findFirstOrThrow({
     where: { orderUID },
@@ -239,36 +238,6 @@ export async function deleteOrderOrThrow(orderUID: Order['orderUID']) {
   await prisma.order.delete({
     where: { orderUID },
   });
-}
-
-export async function deleteOrder(
-  orderUID: Order['orderUID'],
-): Promise<HttpResponse<null, BadRequestError>> {
-  try {
-    await deleteOrderOrThrow(orderUID);
-
-    return {
-      data: null,
-      status: 200,
-    };
-  } catch (err: unknown) {
-    if (err instanceof BadRequestError) {
-      return {
-        data: null,
-        error: {
-          ...err,
-          message: err.message,
-          name: err.name,
-        },
-        status: 400,
-      };
-    }
-
-    return {
-      data: null,
-      status: 500,
-    };
-  }
 }
 
 export interface GetOrdersParams {
@@ -373,11 +342,4 @@ export async function getOrder(
 ): Promise<Order | null> {
   const order = await prisma.order.findUnique({ where: { orderUID } });
   return order || null;
-}
-
-export async function getOrderState(
-  orderUID: Order['orderUID'],
-): Promise<OrderState | null> {
-  const order = await prisma.order.findUnique({ where: { orderUID } });
-  return order?.orderState || null;
 }


### PR DESCRIPTION
- remove the unnecessary getOrderState function
- introduce the concept of a "safe" server action function, which wraps a normal server action catching any errors and returns an `HttpResponse`. Place these functions in separate files to distinguish and also ease the testing burden.