### PR TITLE
feat: port transaction actions to safe functions

### DIFF
--- a/src/app/checkout/[orderUID]/transaction/[transactionUID]/processing/page.tsx
+++ b/src/app/checkout/[orderUID]/transaction/[transactionUID]/processing/page.tsx
@@ -2,7 +2,7 @@
 
 import { Button } from '@/components/ui/button';
 import { LoadingCircle } from '@/components/ui/loading-circle';
-import { cancelTransaction } from '@/lib/actions/transaction';
+import { cancelTransactionSafe } from '@/lib/actions/transaction-safe';
 import useSyncTransactionStatus from '@/lib/hooks/useSyncTransactionStatus';
 import { TransactionStatus } from '@prisma/client';
 import { useRouter } from 'next/navigation';
@@ -44,7 +44,7 @@ export default function CheckoutTransactionProcessingPage({
 
   const onCancel = useCallback(async () => {
     setIsCancelling(true);
-    const response = await cancelTransaction(transactionUID);
+    const response = await cancelTransactionSafe(transactionUID);
     if (response.status === 200) {
       return router.push(cancelUrl);
     } else {

--- a/src/app/checkout/page.tsx
+++ b/src/app/checkout/page.tsx
@@ -14,7 +14,7 @@ import { LoadingSpinner } from '@/components/ui/loading-spinner';
 import { getBook } from '@/lib/actions/book';
 import { createOrder, getOrderWithItems } from '@/lib/actions/order';
 import { createOrderItem } from '@/lib/actions/order-item';
-import { createTransaction } from '@/lib/actions/transaction';
+import { createTransactionSafe } from '@/lib/actions/transaction-safe';
 import OrderWithItemsHydrated from '@/types/OrderWithItemsHydrated';
 import { ProductType } from '@prisma/client';
 import clsx from 'clsx';
@@ -101,7 +101,7 @@ export default function CheckoutPage() {
 
     setIsCreatingTransaction(true);
 
-    const { data, error, status } = await createTransaction(orderUID);
+    const { data, error, status } = await createTransactionSafe(orderUID);
     if (status === 200 && data) {
       const { transactionUID } = data;
       router.push(

--- a/src/lib/actions/transaction-safe.test.ts
+++ b/src/lib/actions/transaction-safe.test.ts
@@ -1,0 +1,149 @@
+import {
+  cancelTransactionSafe,
+  createTransactionSafe,
+  syncTransactionStatusSafe,
+} from '@/lib/actions/transaction-safe';
+import BadRequestError from '@/lib/errors/BadRequestError';
+import NegativeBookQuantityError from '@/lib/errors/NegativeBookQuantityError';
+import { fakeBook } from '@/lib/fakes/book';
+import { fakeTransaction } from '@/lib/fakes/transaction';
+
+const mockCancelTransaction = jest.fn();
+const mockCreateTransaction = jest.fn();
+const mockSyncTransactionStatus = jest.fn();
+jest.mock('./transaction', () => ({
+  ...jest.requireActual('./transaction'),
+  cancelTransaction: (...args: unknown[]) => mockCancelTransaction(...args),
+  createTransaction: (...args: unknown[]) => mockCreateTransaction(...args),
+  syncTransactionStatus: (...args: unknown[]) =>
+    mockSyncTransactionStatus(...args),
+}));
+
+describe('transaction safe actions', () => {
+  const transaction = fakeTransaction();
+
+  beforeEach(() => {
+    mockCancelTransaction.mockReset();
+    mockCreateTransaction.mockReset();
+    mockSyncTransactionStatus.mockReset();
+  });
+
+  describe('createTransactionSafe', () => {
+    it('should return the transaction when createTransaction is successful', async () => {
+      mockCreateTransaction.mockResolvedValue(transaction);
+      expect(await createTransactionSafe('1')).toEqual({
+        data: transaction,
+        status: 200,
+      });
+    });
+
+    it('should return error when createTransaction throws BadRequestError', async () => {
+      mockCreateTransaction.mockRejectedValue(new BadRequestError('bad input'));
+
+      expect(await createTransactionSafe('1')).toEqual({
+        data: null,
+        error: {
+          message: 'bad input',
+          name: BadRequestError.name,
+        },
+        status: 400,
+      });
+    });
+
+    it('should return error when createTransaction throws NegativeBookQuantityError', async () => {
+      const book = fakeBook();
+      mockCreateTransaction.mockRejectedValue(
+        new NegativeBookQuantityError(book),
+      );
+
+      expect(await createTransactionSafe('1')).toEqual({
+        data: null,
+        error: {
+          book,
+          message: 'Attempting to set a negative quantity for Book',
+          name: NegativeBookQuantityError.name,
+        },
+        status: 400,
+      });
+    });
+
+    it('should return error when createTransaction throws Error', async () => {
+      mockCreateTransaction.mockRejectedValue(new Error('unrecognized error'));
+
+      expect(await createTransactionSafe('1')).toEqual({
+        data: null,
+        status: 500,
+      });
+    });
+  });
+
+  describe('syncTransactionStatusSafe', () => {
+    it('should return the transaction when syncTransactionStatus is successful', async () => {
+      mockSyncTransactionStatus.mockResolvedValue(transaction);
+
+      expect(await syncTransactionStatusSafe('1')).toEqual({
+        data: transaction,
+        status: 200,
+      });
+    });
+
+    it('should return error when syncTransactionStatus throws BadRequestError', async () => {
+      mockSyncTransactionStatus.mockRejectedValue(
+        new BadRequestError('bad input'),
+      );
+
+      expect(await syncTransactionStatusSafe('1')).toEqual({
+        data: null,
+        error: {
+          message: 'bad input',
+          name: BadRequestError.name,
+        },
+        status: 400,
+      });
+    });
+
+    it('should return error when syncTransactionStatus throws Error', async () => {
+      mockSyncTransactionStatus.mockRejectedValue(
+        new Error('unrecognized error'),
+      );
+
+      expect(await syncTransactionStatusSafe('1')).toEqual({
+        data: null,
+        status: 500,
+      });
+    });
+  });
+
+  describe('cancelTransactionSafe', () => {
+    it('should return the transaction when cancelTransaction is successful', async () => {
+      mockCancelTransaction.mockResolvedValue(transaction);
+
+      expect(await cancelTransactionSafe('1')).toEqual({
+        data: transaction,
+        status: 200,
+      });
+    });
+
+    it('should return error when cancelTransaction throws BadRequestError', async () => {
+      mockCancelTransaction.mockRejectedValue(new BadRequestError('bad input'));
+
+      expect(await cancelTransactionSafe('1')).toEqual({
+        data: null,
+        error: {
+          message: 'bad input',
+          name: BadRequestError.name,
+        },
+        status: 400,
+      });
+    });
+
+    it('should return error when cancelTransaction throws Error', async () => {
+      mockCancelTransaction.mockRejectedValue(new Error('unrecognized error'));
+
+      expect(await cancelTransactionSafe('1')).toEqual({
+        data: null,
+        status: 500,
+      });
+    });
+  });
+});

--- a/src/lib/actions/transaction-safe.ts
+++ b/src/lib/actions/transaction-safe.ts
@@ -1,0 +1,111 @@
+import {
+  cancelTransaction,
+  createTransaction,
+  syncTransactionStatus,
+} from '@/lib/actions/transaction';
+import BadRequestError from '@/lib/errors/BadRequestError';
+import NegativeBookQuantityError from '@/lib/errors/NegativeBookQuantityError';
+import logger from '@/lib/logger';
+import { HttpResponse } from '@/types/HttpResponse';
+import { Order, Transaction } from '@prisma/client';
+
+export async function createTransactionSafe(
+  orderUID: Order['orderUID'],
+): Promise<
+  HttpResponse<Transaction | null, BadRequestError | NegativeBookQuantityError>
+> {
+  try {
+    const transaction = await createTransaction(orderUID);
+
+    return {
+      data: transaction,
+      status: 200,
+    };
+  } catch (err: unknown) {
+    if (
+      err instanceof BadRequestError ||
+      err instanceof NegativeBookQuantityError
+    ) {
+      return {
+        data: null,
+        error: {
+          ...err,
+          message: err.message,
+          name: err.name,
+        },
+        status: 400,
+      };
+    }
+
+    logger.error('Unknown error occurred in createTransaction');
+    logger.error(err);
+    return {
+      data: null,
+      status: 500,
+    };
+  }
+}
+
+export async function syncTransactionStatusSafe(
+  transactionUID: Transaction['transactionUID'],
+): Promise<HttpResponse<Transaction | null, BadRequestError>> {
+  try {
+    const transaction = await syncTransactionStatus(transactionUID);
+
+    return {
+      data: transaction,
+      status: 200,
+    };
+  } catch (err: unknown) {
+    if (err instanceof BadRequestError) {
+      return {
+        data: null,
+        error: {
+          ...err,
+          message: err.message,
+          name: err.name,
+        },
+        status: 400,
+      };
+    }
+
+    logger.error('Unknown error occurred in syncTransactionStatus');
+    logger.error(err);
+    return {
+      data: null,
+      status: 500,
+    };
+  }
+}
+
+export async function cancelTransactionSafe(
+  transactionUID: Transaction['transactionUID'],
+): Promise<HttpResponse<Transaction | null, BadRequestError>> {
+  try {
+    const transaction = await cancelTransaction(transactionUID);
+
+    return {
+      data: transaction,
+      status: 200,
+    };
+  } catch (err: unknown) {
+    if (err instanceof BadRequestError) {
+      return {
+        data: null,
+        error: {
+          ...err,
+          message: err.message,
+          name: err.name,
+        },
+        status: 400,
+      };
+    }
+
+    logger.error('Unknown error occurred in cancelTransaction');
+    logger.error(err);
+    return {
+      data: null,
+      status: 500,
+    };
+  }
+}

--- a/src/lib/hooks/useSyncTransactionStatus.test.ts
+++ b/src/lib/hooks/useSyncTransactionStatus.test.ts
@@ -8,10 +8,10 @@ import useSyncTransactionStatus, {
 import { TransactionStatus } from '@prisma/client';
 import { act, renderHook } from '@testing-library/react';
 
-const mockSyncTransactionStatus = jest.fn();
-jest.mock('../actions/transaction', () => ({
-  syncTransactionStatus: (...args: unknown[]) =>
-    mockSyncTransactionStatus(...args),
+const mockSyncTransactionStatusSafe = jest.fn();
+jest.mock('../actions/transaction-safe', () => ({
+  syncTransactionStatusSafe: (...args: unknown[]) =>
+    mockSyncTransactionStatusSafe(...args),
 }));
 
 describe('useSyncTransactionStatus', () => {
@@ -24,7 +24,7 @@ describe('useSyncTransactionStatus', () => {
   });
 
   beforeEach(() => {
-    mockSyncTransactionStatus.mockReset();
+    mockSyncTransactionStatusSafe.mockReset();
   });
 
   it('should return perform correctly', async () => {
@@ -39,7 +39,7 @@ describe('useSyncTransactionStatus', () => {
 
     // verify that when the status is PENDING, and we advance time,
     // we see the updated state
-    mockSyncTransactionStatus.mockReturnValue({
+    mockSyncTransactionStatusSafe.mockReturnValue({
       data: { status: TransactionStatus.PENDING },
       status: 200,
     });
@@ -52,7 +52,7 @@ describe('useSyncTransactionStatus', () => {
 
     // verify that when the state changes, and we advance time,
     // we see the updated state
-    mockSyncTransactionStatus.mockReturnValue({
+    mockSyncTransactionStatusSafe.mockReturnValue({
       data: { status: TransactionStatus.COMPLETE },
       status: 200,
     });
@@ -66,7 +66,7 @@ describe('useSyncTransactionStatus', () => {
     // verify that when the state changes, but we have unsubscribed,
     // we do NOT see the updated state
     unsubscribe();
-    mockSyncTransactionStatus.mockReturnValue({
+    mockSyncTransactionStatusSafe.mockReturnValue({
       data: { status: TransactionStatus.CANCELLED },
       status: 200,
     });
@@ -87,7 +87,7 @@ describe('useSyncTransactionStatus', () => {
 
     result.current.subscribe();
 
-    mockSyncTransactionStatus.mockReturnValue({
+    mockSyncTransactionStatusSafe.mockReturnValue({
       data: { status: TransactionStatus.COMPLETE },
       status: 200,
     });
@@ -116,7 +116,7 @@ describe('useSyncTransactionStatus', () => {
 
     result.current.subscribe();
 
-    mockSyncTransactionStatus.mockReturnValue({
+    mockSyncTransactionStatusSafe.mockReturnValue({
       data: { status: TransactionStatus.COMPLETE },
       error: 'bad things!',
       status: 500,

--- a/src/lib/hooks/useSyncTransactionStatus.ts
+++ b/src/lib/hooks/useSyncTransactionStatus.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { syncTransactionStatus } from '@/lib/actions/transaction';
+import { syncTransactionStatusSafe } from '@/lib/actions/transaction-safe';
 import { TransactionStatus } from '@prisma/client';
 import { useCallback, useState } from 'react';
 
@@ -25,7 +25,7 @@ export default function useSyncTransactionStatus({
   const subscribe = useCallback(() => {
     const intervalId = setInterval(async () => {
       const { data, error, status } =
-        await syncTransactionStatus(transactionUID);
+        await syncTransactionStatusSafe(transactionUID);
       if (status === 200 && data) {
         const { status: updatedStatus } = data;
         setTransactionStatus(updatedStatus);


### PR DESCRIPTION
- Move the transactions actions which wrap actions that throw errors to the safe functions, similar to what was done in a previous PR for order actions.