### PR TITLE
feat: simplify get invoice & items

### DIFF
--- a/src/lib/actions/invoice-item.test.ts
+++ b/src/lib/actions/invoice-item.test.ts
@@ -1,12 +1,10 @@
 import { prismaMock } from '../../../test-setup/prisma-mock.setup';
-import { createInvoiceItem, getInvoiceItems } from '@/lib/actions/invoice-item';
+import { createInvoiceItem } from '@/lib/actions/invoice-item';
 import { fakeBook } from '@/lib/fakes/book';
 import {
   fakeInvoiceItem,
   fakeInvoiceItemHydrated,
 } from '@/lib/fakes/invoice-item';
-import { buildPaginationRequest } from '@/lib/pagination';
-import { ProductType } from '@prisma/client';
 
 const mockUpsertBook = jest.fn();
 jest.mock('./book', () => ({
@@ -17,8 +15,6 @@ describe('invoice-item actions', () => {
   const book = fakeBook();
   const invoiceItem1 = fakeInvoiceItem();
   const invoiceItemHydrated1 = fakeInvoiceItemHydrated();
-  const invoiceItemHydrated2 = fakeInvoiceItemHydrated();
-  const invoiceItemHydrated3 = fakeInvoiceItemHydrated();
   beforeEach(() => {
     mockUpsertBook.mockReset();
   });
@@ -74,125 +70,6 @@ describe('invoice-item actions', () => {
       ).rejects.toThrowErrorMatchingInlineSnapshot(
         `"Book required as input at this time"`,
       );
-    });
-  });
-
-  describe('getInvoiceItems', () => {
-    it('should get invoice items when provided with default input', async () => {
-      prismaMock.invoiceItem.findMany.mockResolvedValue([
-        invoiceItemHydrated1,
-        invoiceItemHydrated2,
-        invoiceItemHydrated3,
-      ]);
-
-      const result = await getInvoiceItems({});
-
-      expect(prismaMock.invoiceItem.findMany).toHaveBeenCalledWith({
-        ...buildPaginationRequest({}),
-        include: {
-          book: {
-            include: {
-              authors: true,
-              format: true,
-              genre: true,
-              publisher: true,
-            },
-          },
-        },
-        orderBy: { createdAt: 'desc' },
-        where: {},
-      });
-      expect(result).toEqual({
-        invoiceItems: [
-          invoiceItemHydrated1,
-          invoiceItemHydrated2,
-          invoiceItemHydrated3,
-        ],
-        pageInfo: {
-          endCursor: invoiceItemHydrated3.id.toString(),
-          hasNextPage: false,
-          hasPreviousPage: false,
-          startCursor: invoiceItemHydrated1.id.toString(),
-        },
-      });
-    });
-
-    it('should get invoices when provided with pagination query input', async () => {
-      prismaMock.invoiceItem.findMany.mockResolvedValue([
-        invoiceItemHydrated2,
-        invoiceItemHydrated3,
-      ]);
-
-      const result = await getInvoiceItems({
-        paginationQuery: {
-          after: '1',
-          first: 2,
-        },
-      });
-
-      expect(result).toEqual({
-        invoiceItems: [invoiceItemHydrated2, invoiceItemHydrated3],
-        pageInfo: {
-          endCursor: invoiceItemHydrated3.id.toString(),
-          hasNextPage: false,
-          hasPreviousPage: true,
-          startCursor: invoiceItemHydrated2.id.toString(),
-        },
-      });
-    });
-
-    it('should pass correct values to prisma when provided with invoiceId', async () => {
-      prismaMock.invoiceItem.findMany.mockResolvedValue([]);
-
-      await getInvoiceItems({ invoiceId: 123 });
-
-      expect(prismaMock.invoiceItem.findMany).toHaveBeenCalledWith({
-        ...buildPaginationRequest({}),
-        include: {
-          book: {
-            include: {
-              authors: true,
-              format: true,
-              genre: true,
-              publisher: true,
-            },
-          },
-        },
-        orderBy: { createdAt: 'desc' },
-        where: { invoiceId: 123 },
-      });
-    });
-
-    it('should process non-book product type invoice items', async () => {
-      prismaMock.invoiceItem.findMany.mockResolvedValue([
-        invoiceItemHydrated1,
-        invoiceItemHydrated2,
-        {
-          ...invoiceItemHydrated3,
-          productType: 'foo' as ProductType,
-        },
-      ]);
-
-      const result = await getInvoiceItems({});
-
-      expect(result).toEqual({
-        invoiceItems: [
-          invoiceItemHydrated1,
-          invoiceItemHydrated2,
-          {
-            ...invoiceItemHydrated3,
-            book: undefined,
-            bookId: null,
-            productType: 'foo',
-          },
-        ],
-        pageInfo: {
-          endCursor: invoiceItemHydrated3.id.toString(),
-          hasNextPage: false,
-          hasPreviousPage: false,
-          startCursor: invoiceItemHydrated1.id.toString(),
-        },
-      });
     });
   });
 });

--- a/src/lib/actions/invoice-item.ts
+++ b/src/lib/actions/invoice-item.ts
@@ -2,16 +2,10 @@
 
 import { upsertBook } from '@/lib/actions/book';
 import logger from '@/lib/logger';
-import {
-  buildPaginationRequest,
-  buildPaginationResponse,
-} from '@/lib/pagination';
 import prisma from '@/lib/prisma';
 import { serializeBookSource } from '@/lib/serializers/book-source';
 import InvoiceItemCreateInput from '@/types/InvoiceItemCreateInput';
 import InvoiceItemHydrated from '@/types/InvoiceItemHydrated';
-import PageInfo from '@/types/PageInfo';
-import PaginationQuery from '@/types/PaginationQuery';
 import { ProductType } from '@prisma/client';
 
 export async function createInvoiceItem(
@@ -73,71 +67,4 @@ export async function createInvoiceItem(
   logger.trace('created invoice item in DB: %j', invoiceItemCreated);
 
   return invoiceItemCreated;
-}
-
-export interface GetInvoiceItemsParams {
-  paginationQuery?: PaginationQuery;
-  invoiceId?: number;
-}
-
-export interface GetInvoiceItemsResult {
-  invoiceItems: Array<InvoiceItemHydrated>;
-  pageInfo: PageInfo;
-}
-
-export async function getInvoiceItems({
-  paginationQuery,
-  invoiceId,
-}: GetInvoiceItemsParams): Promise<GetInvoiceItemsResult> {
-  const paginationRequest = buildPaginationRequest({ paginationQuery });
-
-  const rawItems = await prisma.invoiceItem.findMany({
-    ...paginationRequest,
-    include: {
-      book: {
-        include: {
-          authors: true,
-          format: true,
-          genre: true,
-          publisher: true,
-        },
-      },
-    },
-    orderBy: { createdAt: 'desc' },
-    where: { invoiceId },
-  });
-
-  const items = rawItems.map((item) => {
-    if (item.productType !== ProductType.BOOK) {
-      // we have no other product types at this time, so this should not happen
-      logger.warn('non-book product type encountered: %j', item);
-      return {
-        ...item,
-        book: undefined,
-        bookId: null,
-      };
-    }
-
-    // we can assume the book is available based on code above
-    const itemBook = item.book!;
-
-    return {
-      ...item,
-      book: {
-        ...itemBook,
-        publisher: serializeBookSource(itemBook.publisher),
-      },
-    };
-  });
-
-  const { items: invoiceItems, pageInfo } =
-    buildPaginationResponse<InvoiceItemHydrated>({
-      items,
-      paginationQuery,
-    });
-
-  return {
-    invoiceItems,
-    pageInfo,
-  };
 }

--- a/src/lib/fakes/invoice.ts
+++ b/src/lib/fakes/invoice.ts
@@ -1,6 +1,5 @@
-import { fakeVendor } from '@/lib/fakes/book-source';
+import { fakeVendorSerialized } from '@/lib/fakes/book-source';
 import { fakeCreatedAtUpdatedAt } from '@/lib/fakes/created-at-updated-at';
-import { serializeBookSource } from '@/lib/serializers/book-source';
 import InvoiceHydrated from '@/types/InvoiceHydrated';
 import { faker } from '@faker-js/faker';
 import { Invoice } from '@prisma/client';
@@ -27,11 +26,11 @@ export function fakeInvoiceHydrated(
   isCompleted: boolean = false,
 ): InvoiceHydrated {
   const invoice = fakeInvoice(isCompleted);
-  const vendor = fakeVendor();
+  const vendor = fakeVendorSerialized();
 
   return {
     ...invoice,
     numInvoiceItems: faker.number.int(50),
-    vendor: serializeBookSource(vendor),
+    vendor,
   };
 }

--- a/src/types/InvoiceHydratedWithItemsHydrated.ts
+++ b/src/types/InvoiceHydratedWithItemsHydrated.ts
@@ -1,0 +1,7 @@
+import InvoiceHydrated from '@/types/InvoiceHydrated';
+import InvoiceItemHydrated from '@/types/InvoiceItemHydrated';
+
+type InvoiceHydratedWithItemsHydrated = InvoiceHydrated & {
+  invoiceItems: Array<InvoiceItemHydrated>;
+};
+export default InvoiceHydratedWithItemsHydrated;


### PR DESCRIPTION
- Since we expect invoice items to be all displayed on the page at once (and the list total to never be too long), return all invoice items within the getInvoice call.
- Remove the existing getInvoiceItems action since it's no longer being used.