### PR TITLE
test: fix app and invoices e2e tests

### DIFF
--- a/src/components/search/SearchCommand.tsx
+++ b/src/components/search/SearchCommand.tsx
@@ -84,6 +84,7 @@ export default function SearchCommand(props: SearchCommandProps) {
           placeholder={placeholder}
           onValueChange={(value) => onSearchValueChange(value)}
           value={searchValue}
+          data-testid="search-command-input"
         />
         <CommandList>
           {isSearching ? (

--- a/tests/app.spec.ts
+++ b/tests/app.spec.ts
@@ -6,8 +6,8 @@ test.describe('app', () => {
 
     await expect(page.getByRole('main')).toHaveText('Welcome');
 
-    await page.getByRole('navigation').getByText('Search').click();
+    await page.getByRole('navigation').getByText('Orders').click();
 
-    await expect(page.getByRole('heading')).toHaveText('Search');
+    await expect(page.getByRole('heading')).toHaveText('Orders');
   });
 });

--- a/tests/invoices.spec.ts
+++ b/tests/invoices.spec.ts
@@ -281,10 +281,9 @@ test.describe('invoices', () => {
 
     // verify the books via search
     await page.getByRole('navigation').getByText('Search').click();
-    await expect(page.getByRole('heading')).toHaveText('Search');
-
-    await page.getByRole('textbox').fill(book1.title);
-    await page.getByRole('textbox').press('Enter');
+    await page.getByTestId('search-command-input').fill(book1.title);
+    await page.getByTestId('search-command-input').press('Enter');
+    await page.getByText(`${book1.title} by ${book1.authors}`).click();
     await verifyBookDetails({
       book: book1,
       page,
@@ -293,8 +292,10 @@ test.describe('invoices', () => {
       ).toString(),
     });
 
-    await page.getByRole('textbox').fill(book2.title);
-    await page.getByRole('textbox').press('Enter');
+    await page.getByRole('navigation').getByText('Search').click();
+    await page.getByTestId('search-command-input').fill(book2.title);
+    await page.getByTestId('search-command-input').press('Enter');
+    await page.getByText(`${book2.title} by ${book2.authors}`).click();
     await verifyBookDetails({
       book: book2,
       page,


### PR DESCRIPTION
- change the app test to look at orders, since there is no search page anymore
- update the invoices test to correctly navigate search