### PR TITLE
test: checkout e2e test

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,13 @@ The following environment variables are required when using Square:
 - `SQUARE_ACCESS_TOKEN`: The Square environment access token
 - `SQUARE_DEVICE_ID`: The unique ID of the device used for Square Terminal Checkout
 
+### Square Sandbox
+
+Testing is available for Square via the Sandbox environment. In this environment, device IDs are used to simulate scenarios.
+
+For Terminal API Checkout see:
+https://developer.squareup.com/docs/devtools/sandbox/testing#terminal-api-checkouts
+
 ## Logging
 
 [Pino](https://github.com/pinojs/pino) logger is setup to use within the app. Configuration can be found in the [logger.ts](src/lib/logger.ts) file.
@@ -125,7 +132,9 @@ $ bun run test:watch
 
 ### Playwright e2e Tests
 
-Playwright tests are stored in [tests](tests/).
+Playwright tests are stored in [tests](tests/). Some tests require the app to be setup in a specific manner (such as Square sandbox with a specific device ID). See the tests for more details.
+
+Note that these e2e tests are not run via the GitHub CI actions, since they require specific setup. They can be run locally, manually:
 
 To run the tests:
 

--- a/prisma/seed/ci.ts
+++ b/prisma/seed/ci.ts
@@ -1,5 +1,8 @@
 import prisma from '@/lib/prisma';
 import generateCoreSeeds from './core';
+import { upsertBook } from '@/lib/actions/book';
+import { findFormatOrThrow } from '@/lib/actions/format';
+import { findGenreOrThrow } from '@/lib/actions/genre';
 
 async function createVendor(name: string) {
   // TODO replace with create vendor once it exists
@@ -14,8 +17,28 @@ async function createVendor(name: string) {
   });
 }
 
+async function addBookInventory() {
+  const { id: formatId } = await findFormatOrThrow('Trade Paperback');
+  const { id: genreId } = await findGenreOrThrow('Fantasy');
+
+  return await upsertBook({
+    authors: 'Sarah J. Maas',
+    formatId,
+    genreId,
+    imageUrl:
+      'https://books.google.com/books/content?id=N_haEAAAQBAJ&printsec=frontcover&img=1&zoom=1&source=gbs_api',
+    isbn13: BigInt('9781635575583'),
+    priceInCents: 1999,
+    publishedDate: new Date('2020-06-02T05:00:00.000Z'),
+    publisher: 'Bloomsbury Publishing USA',
+    quantity: 5,
+    title: 'A Court of Mist and Fury',
+  });
+}
+
 export default async function generateCiSeeds() {
   await generateCoreSeeds();
 
   await createVendor('Vendor One');
+  await addBookInventory();
 }

--- a/src/app/checkout/[orderUID]/transaction/[transactionUID]/layout.tsx
+++ b/src/app/checkout/[orderUID]/transaction/[transactionUID]/layout.tsx
@@ -37,7 +37,9 @@ export default function CheckoutTransactionLayout({
   return (
     <div className="flex flex-col items-center gap-4 mt-[150px] text-xl text-center">
       <div>
-        <p>Order {order.orderUID}</p>
+        <p>
+          Order <span data-testid="order-uid">{order.orderUID}</span>
+        </p>
         <p>
           Total:{' '}
           <span className="font-bold">

--- a/src/app/orders/[uid]/OrderTotal.tsx
+++ b/src/app/orders/[uid]/OrderTotal.tsx
@@ -3,7 +3,7 @@ import { Order } from '@prisma/client';
 
 export default function OrderTotal({ order }: { order: Order }) {
   return (
-    <div className="grid grid-cols-2 gap-2">
+    <div className="grid grid-cols-2 gap-2" data-testid="order-total">
       <div>Subtotal:</div>
       <div className="text-right">
         <Dollars amountInCents={order.subTotalInCents} />

--- a/src/components/search/Search.tsx
+++ b/src/components/search/Search.tsx
@@ -50,7 +50,11 @@ const Search = React.forwardRef<
     <form className="w-full" onSubmit={handleSubmit(internalOnSubmit)}>
       <div className="flex gap-4 items-end">
         <div className="flex flex-col flex-1">
-          {labelText && <label className="text-sm">{labelText}</label>}
+          {labelText && (
+            <label className="text-sm" htmlFor={labelText}>
+              {labelText}
+            </label>
+          )}
           <InputIcon
             Icon={
               isSearching ? (
@@ -62,6 +66,7 @@ const Search = React.forwardRef<
             asButton
             hasError={hasError}
             onClick={handleSubmit(internalOnSubmit)}
+            id={labelText}
             // https://www.react-hook-form.com/faqs/#Howtosharerefusage
             {...formRest}
             ref={(e) => {

--- a/tests/checkout.spec.ts
+++ b/tests/checkout.spec.ts
@@ -1,0 +1,164 @@
+import { expect, test, Page } from '@playwright/test';
+import { format } from 'date-fns';
+
+type BookStrings = {
+  authors: string;
+  isbn13: string;
+  price: string;
+  title: string;
+};
+
+type OrderTotal = {
+  subTotal: string;
+  tax: string;
+  total: string;
+};
+
+async function addBookToOrder({
+  book,
+  page,
+}: {
+  book: BookStrings;
+  page: Page;
+}) {
+  // enter in an ISBN and press enter
+  const skuInput = page.getByLabel('SKU');
+  await skuInput.fill(book.isbn13);
+  await skuInput.press('Enter');
+
+  // TODO remove this after the animation is removed from the start of checkout
+  await page.waitForTimeout(1000);
+
+  await expect(page.getByText('Pay Now')).toBeVisible();
+
+  // verify the row added to the table
+  const row = page.getByRole('row').nth(1);
+  await expect(row).toHaveText(
+    `${book.isbn13}${book.title}$${book.price}1$${book.price}`,
+  );
+}
+
+async function verifyOrderTotal({
+  subTotal,
+  tax,
+  total,
+  page,
+}: OrderTotal & {
+  page: Page;
+}) {
+  const orderTotal = page.getByTestId('order-total');
+  await expect(orderTotal).toHaveText(
+    `Subtotal:$${subTotal}Tax:$${tax}Total:$${total}`,
+  );
+}
+
+async function payNowAndVerifyOrder({
+  subTotal,
+  tax,
+  total,
+  page,
+}: OrderTotal & {
+  page: Page;
+}) {
+  await page.getByText('Pay Now').click();
+
+  // verify the waiting state
+  await expect(page.getByText('Awaiting transaction')).toBeVisible();
+  await expect(page.getByText(`Total: $${total}`)).toBeVisible();
+  await expect(
+    page.getByRole('button', { name: 'Cancel transaction' }),
+  ).toBeVisible();
+
+  // wait for the order to complete, and verify the complete state
+  await expect(page.getByText('Checkout complete!')).toBeVisible();
+  await expect(page.getByText(`Total: $${total}`)).toBeVisible();
+  await expect(
+    page.getByRole('button', { name: 'Start New Checkout' }),
+  ).toBeVisible();
+
+  const orderId = await page.getByTestId('order-uid').textContent();
+
+  // navigate to the orders page
+  await page.getByRole('navigation').getByText('Orders').click();
+  await expect(page.getByRole('heading')).toHaveText('Orders');
+
+  // verify the row added to the table
+  const row = page.getByRole('row').nth(1);
+  await expect(row).toHaveText(
+    `${orderId}Paid${format(new Date(), 'M/d/yyyy')}1$${subTotal}$${tax}$${total}`,
+  );
+}
+
+async function verifyBookQuantity({
+  book,
+  quantity,
+  page,
+}: {
+  book: BookStrings;
+  quantity: number;
+  page: Page;
+}) {
+  await page.getByRole('navigation').getByText('Search').click();
+  await page.getByTestId('search-command-input').fill(book.title);
+  await page.getByTestId('search-command-input').press('Enter');
+  await page.getByText(`${book.title} by ${book.authors}`).click();
+
+  const bookComponent = page.getByTestId(book.isbn13);
+
+  await expect(bookComponent.getByText(book.title)).toBeVisible();
+  await expect(bookComponent.getByText(`ISBN:${book.isbn13}`)).toBeVisible();
+  await expect(bookComponent.getByText(`By:${book.authors}`)).toBeVisible();
+  await expect(bookComponent.getByText(`Quantity:${quantity}`)).toBeVisible();
+}
+
+/**
+ * This test assumes inventory exists for the book described below, which
+ * should be seeded via the CI seed script.
+ *
+ * This test assumes Square checkout is being run in sandbox mode, and that
+ * the sandbox mode is setup for a successful transaction for orders < $25.
+ */
+test.describe('checkout', () => {
+  test('checkout book with inventory, and successful square transaction', async ({
+    page,
+  }) => {
+    const book1: BookStrings = {
+      authors: 'Sarah J. Maas',
+      isbn13: '9781635575583',
+      price: '19.99',
+      title: 'A Court of Mist and Fury',
+    };
+    const orderTotal: OrderTotal = {
+      subTotal: '19.99',
+      tax: '1.65',
+      total: '21.64',
+    };
+    // we have 5 to start, and we're buying 1, so we'll have 4 remaining
+    const QUANTITY_REMAINING = 4;
+
+    await page.goto('/');
+    await expect(page.getByRole('main')).toHaveText('Welcome');
+
+    // navigate to the checkout page
+    await page.getByRole('navigation').getByText('Checkout').click();
+    await expect(page.getByRole('heading')).toHaveText('Checkout');
+
+    await addBookToOrder({ book: book1, page });
+
+    await verifyOrderTotal({
+      page,
+      ...orderTotal,
+    });
+
+    await payNowAndVerifyOrder({
+      page,
+      ...orderTotal,
+    });
+
+    await verifyBookQuantity({
+      book: book1,
+      page,
+      quantity: QUANTITY_REMAINING,
+    });
+  });
+});


### PR DESCRIPTION
Add an end to end test for checkout. This requires some inventory to begin with, so update our CI seed script to add books.

The test adds that book to the order, then pays with square, and verifies the order entry exists along with subtracting the inventory from the book. For square, this means we must be setup in sandbox for this test, with a setup that will mark the transaction complete for orders totaling less than $25.

Update the readme to help describe all of this :)