### PR TITLE
feat: improve invoice item quantity

### DIFF
--- a/prisma/seed/fake.ts
+++ b/prisma/seed/fake.ts
@@ -119,7 +119,7 @@ async function generateInvoiceItem(props: GenerateInvoiceItemProps) {
   const book = buildBookCreateInput(baseProps);
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { id, bookId, createdAt, updatedAt, ...data } = fakeInvoiceItem();
+  const { id, bookId, createdAt, updatedAt, ...data } = fakeInvoiceItem({});
 
   return await createInvoiceItem({
     ...data,

--- a/src/components/invoice-item/InvoiceItemsTable.tsx
+++ b/src/components/invoice-item/InvoiceItemsTable.tsx
@@ -94,7 +94,7 @@ const columns: ColumnDef<InvoiceItemHydrated>[] = [
         <>{props.getValue()}</>
       </div>
     ),
-    header: ({ column }) => <SortableHeader column={column} text="#" />,
+    header: ({ column }) => <SortableHeader column={column} text="Qty" />,
   },
   {
     accessorKey: 'totalCostInCents',

--- a/src/components/invoice/InvoicesTable.tsx
+++ b/src/components/invoice/InvoicesTable.tsx
@@ -38,7 +38,7 @@ const columns: ColumnDef<InvoiceHydrated>[] = [
         <>{props.getValue()}</>
       </div>
     ),
-    header: ({ column }) => <SortableHeader column={column} text="Items" />,
+    header: ({ column }) => <SortableHeader column={column} text="Qty" />,
   },
   {
     accessorKey: 'isCompleted',

--- a/src/components/stories/invoice-item/InvoiceItemsTable.stories.tsx
+++ b/src/components/stories/invoice-item/InvoiceItemsTable.stories.tsx
@@ -13,7 +13,7 @@ type Story = StoryObj<typeof InvoiceItemsTable>;
 
 function getInvoiceItems() {
   return _.times(9, (): InvoiceItemHydrated => {
-    const invoiceItem = fakeInvoiceItemHydrated();
+    const invoiceItem = fakeInvoiceItemHydrated({});
     return Math.random() > 0.2
       ? invoiceItem
       : {

--- a/src/lib/actions/invoice-item.test.ts
+++ b/src/lib/actions/invoice-item.test.ts
@@ -13,8 +13,8 @@ jest.mock('./book', () => ({
 
 describe('invoice-item actions', () => {
   const book = fakeBook();
-  const invoiceItem1 = fakeInvoiceItem();
-  const invoiceItemHydrated1 = fakeInvoiceItemHydrated();
+  const invoiceItem1 = fakeInvoiceItem({});
+  const invoiceItemHydrated1 = fakeInvoiceItemHydrated({});
   beforeEach(() => {
     mockUpsertBook.mockReset();
   });

--- a/src/lib/actions/invoice.test.ts
+++ b/src/lib/actions/invoice.test.ts
@@ -22,17 +22,17 @@ describe('invoice actions', () => {
   const invoice1 = fakeInvoice(false);
   const resolvedInvoice1 = {
     ...invoice1,
-    _count: { invoiceItems: 3 },
+    invoiceItems: [fakeInvoiceItem({ quantity: 3 })],
   } as Invoice;
   const invoice2 = fakeInvoice(true);
   const resolvedInvoice2 = {
     ...invoice2,
-    _count: { invoiceItems: 8 },
+    invoiceItems: [fakeInvoiceItem({ quantity: 8 })],
   } as Invoice;
   const invoice3 = fakeInvoice(false);
   const resolvedInvoice3 = {
     ...invoice3,
-    _count: { invoiceItems: 0 },
+    invoiceItems: [fakeInvoiceItem({ quantity: 0 })],
   } as Invoice;
 
   beforeAll(() => {
@@ -73,19 +73,17 @@ describe('invoice actions', () => {
 
       const book1 = fakeBook();
       book1.quantity = 7;
-      const item1 = fakeInvoiceItem();
+      const item1 = fakeInvoiceItem({ quantity: 5 });
       item1.bookId = book1.id;
-      item1.quantity = 5;
       prismaMock.book.findUniqueOrThrow.mockResolvedValueOnce(book1);
 
       const book2 = fakeBook();
       book2.quantity = 0;
-      const item2 = fakeInvoiceItem();
+      const item2 = fakeInvoiceItem({ quantity: 3 });
       item2.bookId = book2.id;
-      item2.quantity = 3;
       prismaMock.book.findUniqueOrThrow.mockResolvedValueOnce(book2);
 
-      const item3 = fakeInvoiceItem();
+      const item3 = fakeInvoiceItem({ quantity: 1 });
       // item3 has same bookId as item1
       item3.bookId = book1.id;
       item3.quantity = 1;
@@ -119,9 +117,7 @@ describe('invoice actions', () => {
           isCompleted: true,
         },
         include: {
-          _count: {
-            select: { invoiceItems: true },
-          },
+          invoiceItems: true,
           vendor: true,
         },
         where: { id: invoice1.id },
@@ -129,7 +125,6 @@ describe('invoice actions', () => {
 
       expect(result).toEqual({
         ...invoice1,
-        _count: { invoiceItems: 3 },
         numInvoiceItems: 3,
       });
     });
@@ -138,11 +133,11 @@ describe('invoice actions', () => {
       prismaMock.$transaction.mockImplementation((cb) => cb(prismaMock));
 
       const book1 = fakeBook();
-      const item1 = fakeInvoiceItem();
+      const item1 = fakeInvoiceItem({});
       item1.bookId = book1.id;
       prismaMock.book.findUniqueOrThrow.mockResolvedValueOnce(book1);
 
-      const item2 = fakeInvoiceItem();
+      const item2 = fakeInvoiceItem({});
       // item2 is not a BOOK product type
       item2.productType = 'foo' as ProductType;
       item2.bookId = null;
@@ -170,9 +165,7 @@ describe('invoice actions', () => {
       expect(prismaMock.invoice.findMany).toHaveBeenCalledWith({
         ...buildPaginationRequest({}),
         include: {
-          _count: {
-            select: { invoiceItems: true },
-          },
+          invoiceItems: true,
           vendor: true,
         },
         orderBy: { createdAt: 'desc' },
@@ -180,15 +173,15 @@ describe('invoice actions', () => {
       expect(result).toEqual({
         invoices: [
           {
-            ...resolvedInvoice1,
+            ...invoice1,
             numInvoiceItems: 3,
           },
           {
-            ...resolvedInvoice2,
+            ...invoice2,
             numInvoiceItems: 8,
           },
           {
-            ...resolvedInvoice3,
+            ...invoice3,
             numInvoiceItems: 0,
           },
         ],
@@ -217,11 +210,11 @@ describe('invoice actions', () => {
       expect(result).toEqual({
         invoices: [
           {
-            ...resolvedInvoice2,
+            ...invoice2,
             numInvoiceItems: 8,
           },
           {
-            ...resolvedInvoice3,
+            ...invoice3,
             numInvoiceItems: 0,
           },
         ],
@@ -238,12 +231,11 @@ describe('invoice actions', () => {
   describe('getInvoiceWithItems', () => {
     it('should provide the correct input to prisma', async () => {
       const invoice = fakeInvoice(false);
-      const invoiceItemHydrated1 = fakeInvoiceItemHydrated();
-      const invoiceItemHydrated2 = fakeInvoiceItemHydrated();
+      const invoiceItemHydrated1 = fakeInvoiceItemHydrated({ quantity: 2 });
+      const invoiceItemHydrated2 = fakeInvoiceItemHydrated({ quantity: 3 });
 
       prismaMock.invoice.findUnique.mockResolvedValue({
         ...invoice,
-        _count: { invoiceItems: 2 },
         invoiceItems: [
           invoiceItemHydrated1,
           {
@@ -257,9 +249,6 @@ describe('invoice actions', () => {
 
       expect(prismaMock.invoice.findUnique).toHaveBeenCalledWith({
         include: {
-          _count: {
-            select: { invoiceItems: true },
-          },
           invoiceItems: {
             include: {
               book: {
@@ -279,7 +268,6 @@ describe('invoice actions', () => {
       });
       expect(result).toEqual({
         ...invoice,
-        _count: { invoiceItems: 2 },
         invoiceItems: [
           invoiceItemHydrated1,
           {
@@ -289,7 +277,7 @@ describe('invoice actions', () => {
             productType: 'foo',
           },
         ],
-        numInvoiceItems: 2,
+        numInvoiceItems: 5,
       });
     });
 

--- a/src/lib/fakes/invoice-item.ts
+++ b/src/lib/fakes/invoice-item.ts
@@ -4,12 +4,20 @@ import { convertDollarsToCents } from '@/lib/money';
 import InvoiceItemHydrated from '@/types/InvoiceItemHydrated';
 import { faker } from '@faker-js/faker';
 import { InvoiceItem, ProductType } from '@prisma/client';
+import _ from 'lodash';
 
-export function fakeInvoiceItem(): InvoiceItem {
+export function fakeInvoiceItem({
+  quantity: inboundQuantity,
+}: {
+  quantity?: number;
+}): InvoiceItem {
   const itemCostInCents =
     convertDollarsToCents(faker.commerce.price({ max: 20 })) + 99;
-  const quantity =
-    Math.random() > 0.3 ? 1 : faker.number.int({ max: 10, min: 1 });
+  const quantity = _.isNumber(inboundQuantity)
+    ? inboundQuantity
+    : Math.random() > 0.3
+      ? 1
+      : faker.number.int({ max: 10, min: 1 });
   const totalCostInCents = itemCostInCents * quantity;
 
   return {
@@ -24,8 +32,12 @@ export function fakeInvoiceItem(): InvoiceItem {
   };
 }
 
-export function fakeInvoiceItemHydrated(): InvoiceItemHydrated {
-  const invoiceItem = fakeInvoiceItem();
+export function fakeInvoiceItemHydrated({
+  quantity,
+}: {
+  quantity?: number;
+}): InvoiceItemHydrated {
+  const invoiceItem = fakeInvoiceItem({ quantity });
   const book = fakeBookHydrated();
 
   return {


### PR DESCRIPTION
- update the code such that the invoice now reports the total quantity of all products within all invoice items in an invoice
- update the fake invoice generator to allow for quantity so we can easily test this new functionality
- (polish): change the invoice tables to say "Qty" for the quantity amount