### PR TITLE
feat: homepage and icons

### DIFF
--- a/src/app/invoices/[id]/InvoiceDescription.tsx
+++ b/src/app/invoices/[id]/InvoiceDescription.tsx
@@ -1,6 +1,6 @@
 import { discountPercentageToDisplayString } from '@/lib/money';
 import InvoiceHydrated from '@/types/InvoiceHydrated';
-import { NotepadTextIcon } from 'lucide-react';
+import { PackageOpenIcon } from 'lucide-react';
 
 export default function InvoiceDescription({
   invoice,
@@ -15,7 +15,7 @@ export default function InvoiceDescription({
     >
       <div className="flex flex-col">
         <div className="font-bold flex gap-2 items-center">
-          <NotepadTextIcon /> Invoice Details
+          <PackageOpenIcon /> Invoice Details
         </div>
         <div data-testid="vendor-name">{vendor.name}</div>
         <div className="grid grid-cols-2">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,68 @@
+import { Button } from '@/components/ui/button';
+import { Separator } from '@/components/ui/separator';
+import {
+  ClipboardListIcon,
+  GiftIcon,
+  PackageOpenIcon,
+  ShoppingCartIcon,
+} from 'lucide-react';
+import Link from 'next/link';
+
+function NavLink({
+  children,
+  disabled,
+  path,
+}: {
+  children: React.ReactNode;
+  disabled?: boolean; // TODO deleteme once we have no more disabled buttons
+  path: string;
+}) {
+  const buttonContent = (
+    <Button
+      variant="outline"
+      className="flex items-center gap-2 py-0 h-8 w-[150px]"
+      disabled={disabled}
+    >
+      {children}
+    </Button>
+  );
+
+  return (
+    <>
+      {disabled ? (
+        <div className="h-[50px] flex items-center">{buttonContent}</div>
+      ) : (
+        <Link href={path} className="h-[50px] flex items-center">
+          {buttonContent}
+        </Link>
+      )}
+    </>
+  );
+}
+
 export default function HomePage() {
   return (
-    <div className="flex min-h-screen justify-center items-center">Welcome</div>
+    <div className="flex flex-col w-full items-center mt-[80px] gap-4">
+      <h1>Bookstore</h1>
+      <Separator className="bg-customPalette-200 my-4" />
+      <div className="grid grid-cols-2 gap-x-8 gap-y-2">
+        <NavLink path="/checkout">
+          <ShoppingCartIcon size={14} />
+          Checkout
+        </NavLink>
+        <NavLink path="/invoices">
+          <PackageOpenIcon size={14} />
+          Invoices
+        </NavLink>
+        <NavLink path="/orders">
+          <GiftIcon size={14} />
+          Orders
+        </NavLink>
+        <NavLink path="#" disabled>
+          <ClipboardListIcon size={14} />
+          Reports
+        </NavLink>
+      </div>
+    </div>
   );
 }

--- a/src/components/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs.tsx
@@ -25,7 +25,11 @@ const BreadcrumbsLink = React.forwardRef<
     href: string;
   }
 >(({ children, className, href }, ref) => (
-  <Link ref={ref} href={href} className={className}>
+  <Link
+    ref={ref}
+    href={href}
+    className={cn('flex items-center gap-2', className)}
+  >
     {children}
   </Link>
 ));
@@ -35,7 +39,7 @@ const BreadcrumbsText = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ children, className }, ref) => (
-  <div ref={ref} className={className}>
+  <div ref={ref} className={cn('flex items-center gap-2', className)}>
     {children}
   </div>
 ));

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -5,7 +5,7 @@ import { Button } from '@/components/ui/button';
 import clsx from 'clsx';
 import {
   GiftIcon,
-  NotepadTextIcon,
+  PackageOpenIcon,
   ShoppingCartIcon,
   UserIcon,
 } from 'lucide-react';
@@ -53,7 +53,7 @@ export default function Nav() {
           Orders
         </NavLink>
         <NavLink path="/invoices">
-          <NotepadTextIcon size={14} />
+          <PackageOpenIcon size={14} />
           Invoices
         </NavLink>
       </div>


### PR DESCRIPTION
- add some content to the homepage, including nav buttons for the sections of the app
- change the invoice icon
- drive-by: center the content in breadcrumbs in case multiple items are passed