### PR TITLE
feat: update DB to include invoice totals

### DIFF
--- a/prisma/migrations/20240418163519_invoice_total/migration.sql
+++ b/prisma/migrations/20240418163519_invoice_total/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Invoice"
+ADD COLUMN     "subTotalInCents" INTEGER NOT NULL,
+ADD COLUMN     "taxInCents" INTEGER NOT NULL,
+ADD COLUMN     "totalInCents" INTEGER NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -82,13 +82,16 @@ model Genre {
 }
 
 model Invoice {
-  id            Int       @id @default(autoincrement())
-  createdAt     DateTime  @default(now()) @db.Timestamptz(3)
-  updatedAt     DateTime? @updatedAt @db.Timestamptz(3)
-  invoiceNumber String
-  invoiceDate   DateTime  @db.Timestamptz(1)
-  dateReceived  DateTime? @db.Timestamptz(1)
-  isCompleted   Boolean   @default(false)
+  id              Int       @id @default(autoincrement())
+  createdAt       DateTime  @default(now()) @db.Timestamptz(3)
+  updatedAt       DateTime? @updatedAt @db.Timestamptz(3)
+  invoiceNumber   String
+  invoiceDate     DateTime  @db.Timestamptz(1)
+  dateReceived    DateTime? @db.Timestamptz(1)
+  isCompleted     Boolean   @default(false)
+  subTotalInCents Int
+  taxInCents      Int
+  totalInCents    Int
 
   vendor   BookSource @relation(fields: [vendorId], references: [id])
   vendorId Int

--- a/src/lib/actions/invoice.test.ts
+++ b/src/lib/actions/invoice.test.ts
@@ -53,6 +53,9 @@ describe('invoice actions', () => {
         data: {
           invoiceDate: invoice1.invoiceDate,
           invoiceNumber: invoice1.invoiceNumber,
+          subTotalInCents: 0,
+          taxInCents: 0,
+          totalInCents: 0,
           vendorId: invoice1.vendorId,
         },
         include: {

--- a/src/lib/actions/invoice.ts
+++ b/src/lib/actions/invoice.ts
@@ -24,6 +24,9 @@ export async function createInvoice(
     data: {
       invoiceDate,
       invoiceNumber,
+      subTotalInCents: 0,
+      taxInCents: 0,
+      totalInCents: 0,
       vendorId,
     },
     include: {

--- a/src/lib/fakes/invoice.ts
+++ b/src/lib/fakes/invoice.ts
@@ -1,5 +1,6 @@
 import { fakeVendorSerialized } from '@/lib/fakes/book-source';
 import { fakeCreatedAtUpdatedAt } from '@/lib/fakes/created-at-updated-at';
+import { computeTax, convertDollarsToCents } from '@/lib/money';
 import InvoiceHydrated from '@/types/InvoiceHydrated';
 import { faker } from '@faker-js/faker';
 import { Invoice } from '@prisma/client';
@@ -11,6 +12,12 @@ export function fakeInvoice(isCompleted: boolean = false): Invoice {
     ? add(new Date(invoiceDate), { days: 1 })
     : null;
 
+  const subTotalInCents = convertDollarsToCents(
+    faker.commerce.price({ max: 50, min: 2 }),
+  );
+  const taxInCents = computeTax(subTotalInCents);
+  const totalInCents = subTotalInCents + taxInCents;
+
   return {
     ...fakeCreatedAtUpdatedAt(),
     dateReceived,
@@ -18,6 +25,9 @@ export function fakeInvoice(isCompleted: boolean = false): Invoice {
     invoiceDate: faker.date.past(),
     invoiceNumber: faker.finance.accountNumber(),
     isCompleted,
+    subTotalInCents,
+    taxInCents,
+    totalInCents,
     vendorId: faker.number.int(),
   };
 }


### PR DESCRIPTION
- This was just missed on the original implementation, but we need to include the invoice totals for an invoice (subtotal, tax, total)
- For this first pass, simply supply 0 for all values. We'll later come back and update the values as the invoice items are added.