### PR TITLE
feat: wrap createInvoiceItem in transaction

### DIFF
--- a/src/lib/actions/book.test.ts
+++ b/src/lib/actions/book.test.ts
@@ -94,9 +94,12 @@ describe('book actions', () => {
       prismaMock.book.upsert.mockResolvedValue(book1);
 
       const result = await upsertBook({
-        ...book1,
-        authors: 'author1',
-        publisher: 'publisher2',
+        book: {
+          ...book1,
+          authors: 'author1',
+          publisher: 'publisher2',
+        },
+        tx: prismaMock,
       });
 
       expect(prismaMock.book.upsert).toHaveBeenCalledWith({

--- a/src/lib/actions/invoice-item.test.ts
+++ b/src/lib/actions/invoice-item.test.ts
@@ -25,6 +25,8 @@ describe('invoice-item actions', () => {
     });
 
     it('should create a new invoice item', async () => {
+      prismaMock.$transaction.mockImplementation((cb) => cb(prismaMock));
+
       prismaMock.invoiceItem.create.mockResolvedValue(invoiceItemHydrated1);
 
       const result = await createInvoiceItem({


### PR DESCRIPTION
- we should include the entire create invoice item code in a transaction, and use that same transaction in the upsertBook code path
- update code surrounding this to comply with the changes