### PR TITLE
feat: recompute invoice totals

### DIFF
--- a/src/lib/actions/invoice-item.ts
+++ b/src/lib/actions/invoice-item.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { upsertBook } from '@/lib/actions/book';
+import { recomputeInvoiceTotals } from '@/lib/actions/invoice';
 import logger from '@/lib/logger';
 import prisma from '@/lib/prisma';
 import { serializeBookSource } from '@/lib/serializers/book-source';
@@ -67,6 +68,8 @@ export async function createInvoiceItem(
       };
 
       logger.trace('created invoice item in DB: %j', invoiceItemCreated);
+
+      await recomputeInvoiceTotals({ invoiceItem: rawInvoiceItem, tx });
 
       return invoiceItemCreated;
     },

--- a/src/lib/actions/order-item.test.ts
+++ b/src/lib/actions/order-item.test.ts
@@ -21,7 +21,7 @@ describe('order item actions', () => {
       orderItem1.bookId = book1.id;
       prismaMock.orderItem.create.mockResolvedValue(orderItem1);
 
-      await createOrderItem({
+      const result = await createOrderItem({
         ...orderItem1,
         orderUID: order1.orderUID,
       });
@@ -53,6 +53,8 @@ describe('order item actions', () => {
         },
         where: { id: order1.id },
       });
+
+      expect(result).toEqual(orderItem1);
     });
 
     it('should throw error without book', async () => {


### PR DESCRIPTION
- when creating an invoice item, update the invoice totals with the data from the invoice item
- drive-by: add a missing check in the order-item test