### PR TITLE
feat: format/genre remove pagination

### DIFF
--- a/src/app/invoices/[id]/page.tsx
+++ b/src/app/invoices/[id]/page.tsx
@@ -35,22 +35,12 @@ export default function InvoicePage({ params }: { params: { id: string } }) {
   }, [invoiceId]);
 
   const loadFormats = useCallback(async () => {
-    // TODO handle pagination
-    const { formats } = await getFormats({
-      paginationQuery: {
-        first: 100,
-      },
-    });
+    const formats = await getFormats();
     setFormats(formats);
   }, []);
 
   const loadGenres = useCallback(async () => {
-    // TODO handle pagination
-    const { genres } = await getGenres({
-      paginationQuery: {
-        first: 100,
-      },
-    });
+    const genres = await getGenres();
     setGenres(genres);
   }, []);
 

--- a/src/lib/actions/format.test.ts
+++ b/src/lib/actions/format.test.ts
@@ -15,38 +15,9 @@ describe('format actions', () => {
     it('should get books when provided with default input', async () => {
       prismaMock.format.findMany.mockResolvedValue([format1, format2, format3]);
 
-      const result = await getFormats({});
+      const result = await getFormats();
 
-      expect(result).toEqual({
-        formats: [format1, format2, format3],
-        pageInfo: {
-          endCursor: format3.id.toString(),
-          hasNextPage: false,
-          hasPreviousPage: false,
-          startCursor: format1.id.toString(),
-        },
-      });
-    });
-
-    it('should get books when provided with pagination query input', async () => {
-      prismaMock.format.findMany.mockResolvedValue([format2, format3]);
-
-      const result = await getFormats({
-        paginationQuery: {
-          after: '1',
-          first: 2,
-        },
-      });
-
-      expect(result).toEqual({
-        formats: [format2, format3],
-        pageInfo: {
-          endCursor: format3.id.toString(),
-          hasNextPage: false,
-          hasPreviousPage: true,
-          startCursor: format2.id.toString(),
-        },
-      });
+      expect(result).toEqual([format1, format2, format3]);
     });
   });
 

--- a/src/lib/actions/format.ts
+++ b/src/lib/actions/format.ts
@@ -1,41 +1,12 @@
 'use server';
 
-import {
-  buildPaginationRequest,
-  buildPaginationResponse,
-} from '@/lib/pagination';
 import prisma from '@/lib/prisma';
-import PageInfo from '@/types/PageInfo';
-import PaginationQuery from '@/types/PaginationQuery';
 import { Format } from '@prisma/client';
 
-export interface GetFormatsParams {
-  paginationQuery?: PaginationQuery;
-}
+export async function getFormats(): Promise<Array<Format>> {
+  const formats = await prisma.format.findMany();
 
-export interface GetFormatsResult {
-  formats: Array<Format>;
-  pageInfo: PageInfo;
-}
-
-export async function getFormats({
-  paginationQuery,
-}: GetFormatsParams): Promise<GetFormatsResult> {
-  const paginationRequest = buildPaginationRequest({ paginationQuery });
-
-  const items = await prisma.format.findMany({
-    ...paginationRequest,
-  });
-
-  const { items: formats, pageInfo } = buildPaginationResponse<Format>({
-    items,
-    paginationQuery,
-  });
-
-  return {
-    formats,
-    pageInfo,
-  };
+  return formats;
 }
 
 export async function findFormat(displayName: string): Promise<Format | null> {

--- a/src/lib/actions/genre.test.ts
+++ b/src/lib/actions/genre.test.ts
@@ -11,38 +11,9 @@ describe('genre actions', () => {
     it('should get books when provided with default input', async () => {
       prismaMock.genre.findMany.mockResolvedValue([genre1, genre2, genre3]);
 
-      const result = await getGenres({});
+      const result = await getGenres();
 
-      expect(result).toEqual({
-        genres: [genre1, genre2, genre3],
-        pageInfo: {
-          endCursor: genre3.id.toString(),
-          hasNextPage: false,
-          hasPreviousPage: false,
-          startCursor: genre1.id.toString(),
-        },
-      });
-    });
-
-    it('should get books when provided with pagination query input', async () => {
-      prismaMock.genre.findMany.mockResolvedValue([genre2, genre3]);
-
-      const result = await getGenres({
-        paginationQuery: {
-          after: '1',
-          first: 2,
-        },
-      });
-
-      expect(result).toEqual({
-        genres: [genre2, genre3],
-        pageInfo: {
-          endCursor: genre3.id.toString(),
-          hasNextPage: false,
-          hasPreviousPage: true,
-          startCursor: genre2.id.toString(),
-        },
-      });
+      expect(result).toEqual([genre1, genre2, genre3]);
     });
   });
 

--- a/src/lib/actions/genre.ts
+++ b/src/lib/actions/genre.ts
@@ -1,9 +1,5 @@
 'use server';
 
-import {
-  buildPaginationRequest,
-  buildPaginationResponse,
-} from '@/lib/pagination';
 import prisma from '@/lib/prisma';
 import PageInfo from '@/types/PageInfo';
 import PaginationQuery from '@/types/PaginationQuery';
@@ -18,24 +14,10 @@ export interface GetGenresResult {
   pageInfo: PageInfo;
 }
 
-export async function getGenres({
-  paginationQuery,
-}: GetGenresParams): Promise<GetGenresResult> {
-  const paginationRequest = buildPaginationRequest({ paginationQuery });
+export async function getGenres(): Promise<Array<Genre>> {
+  const genres = await prisma.genre.findMany();
 
-  const items = await prisma.genre.findMany({
-    ...paginationRequest,
-  });
-
-  const { items: genres, pageInfo } = buildPaginationResponse<Genre>({
-    items,
-    paginationQuery,
-  });
-
-  return {
-    genres,
-    pageInfo,
-  };
+  return genres;
 }
 
 export async function findGenre(displayName: string): Promise<Genre | null> {


### PR DESCRIPTION
For Format and Genre, we expect few entries to exist (10 or less in each?). Because of this, let's remove the complexity of pagination and just return all entries found.