### PR TITLE
feat: AppContextProvider

### DIFF
--- a/src/app/AppContextProvider.tsx
+++ b/src/app/AppContextProvider.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import AppContext from '@/app/AppContext';
+import useGenerateAppContext from '@/lib/hooks/useGenerateAppContext';
+import { LoadingSpinner } from '@/components/ui/loading-spinner';
+
+export default function AppContextProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const appContext = useGenerateAppContext();
+
+  if (!appContext) {
+    return (
+      <div className="flex h-screen w-screen items-center justify-center">
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  return (
+    <AppContext.Provider value={appContext}>{children}</AppContext.Provider>
+  );
+}

--- a/src/app/invoices/[id]/page.tsx
+++ b/src/app/invoices/[id]/page.tsx
@@ -3,6 +3,7 @@
 import BookForm from '@/app/invoices/[id]/BookForm';
 import InvoiceDescription from '@/app/invoices/[id]/InvoiceDescription';
 import InvoiceTotal from '@/app/invoices/[id]/InvoiceTotal';
+import useAppContext from '@/lib/hooks/useAppContext';
 import {
   Breadcrumbs,
   BreadcrumbsHome,
@@ -13,19 +14,15 @@ import {
 import InvoiceItemsTable from '@/components/invoice-item/InvoiceItemsTable';
 import { Button } from '@/components/ui/button';
 import { LoadingSpinner } from '@/components/ui/loading-spinner';
-import { getFormats } from '@/lib/actions/format';
-import { getGenres } from '@/lib/actions/genre';
 import { completeInvoice, getInvoiceWithItems } from '@/lib/actions/invoice';
 import InvoiceHydratedWithItemsHydrated from '@/types/InvoiceHydratedWithItemsHydrated';
-import { Format, Genre } from '@prisma/client';
 import _ from 'lodash';
 import { useCallback, useEffect, useState } from 'react';
 
 export default function InvoicePage({ params }: { params: { id: string } }) {
+  const { formats, genres } = useAppContext();
   const [invoice, setInvoice] =
     useState<InvoiceHydratedWithItemsHydrated | null>();
-  const [formats, setFormats] = useState<Array<Format>>();
-  const [genres, setGenres] = useState<Array<Genre>>();
 
   const invoiceId = _.toNumber(params.id);
 
@@ -34,24 +31,11 @@ export default function InvoicePage({ params }: { params: { id: string } }) {
     setInvoice(invoice);
   }, [invoiceId]);
 
-  const loadFormats = useCallback(async () => {
-    const formats = await getFormats();
-    setFormats(formats);
-  }, []);
-
-  const loadGenres = useCallback(async () => {
-    const genres = await getGenres();
-    setGenres(genres);
-  }, []);
-
-  // on initial render, load all the things
   useEffect(() => {
     loadInvoice();
-    loadFormats();
-    loadGenres();
-  }, [loadFormats, loadGenres, loadInvoice]);
+  }, [loadInvoice]);
 
-  if (!invoice || !formats || !genres) {
+  if (!invoice) {
     return (
       <div className="flex h-full items-center justify-center">
         <LoadingSpinner />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import './globals.css';
 import Nav from '@/components/Nav';
+import Providers from '@/app/providers';
 
 export const metadata: Metadata = {
   description: 'bookstore app',
@@ -15,14 +16,16 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className="min-h-screen min-w-screen flex flex-col">
-        <Nav />
-        <div className="flex flex-1">
-          <main className="flex flex-col flex-1 md:items-center mb-12">
-            <div className="w-full h-full px-4 md:w-[768px] md:px-0">
-              {children}
-            </div>
-          </main>
-        </div>
+        <Providers>
+          <Nav />
+          <div className="flex flex-1">
+            <main className="flex flex-col flex-1 md:items-center mb-12">
+              <div className="w-full h-full px-4 md:w-[768px] md:px-0">
+                {children}
+              </div>
+            </main>
+          </div>
+        </Providers>
       </body>
     </html>
   );

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import AppContextProvider from '@/app/AppContextProvider';
+
+export default function Providers({ children }: { children: React.ReactNode }) {
+  return <AppContextProvider>{children}</AppContextProvider>;
+}


### PR DESCRIPTION
- Add app/providers along with an AppContextProvider which generates the AppContext and provides a value
- Include the providers in the main app layout
- With all of this in place, we can remove the loadFormats/loadGenres from the invoice page and instead use the app context to get those values