### PR TITLE
feat: orderItem foreign key case change

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -34,7 +34,7 @@ model Book {
   priceInCents Int
   quantity     Int           @default(0)
   invoiceItems InvoiceItem[]
-  OrderItem    OrderItem[]
+  orderItem    OrderItem[]
 }
 
 model Author {


### PR DESCRIPTION
- Mistakenly named the key for orderItem as OrderItem. This update changes that. No migrations are necessary.