### PR TITLE
feat: getOrderWithItems orderBy: asc

### DIFF
--- a/src/lib/actions/order.test.ts
+++ b/src/lib/actions/order.test.ts
@@ -529,7 +529,7 @@ describe('order action', () => {
                 },
               },
             },
-            orderBy: { createdAt: 'desc' },
+            orderBy: { createdAt: 'asc' },
           },
         },
         where: { orderUID: 'uid123' },

--- a/src/lib/actions/order.ts
+++ b/src/lib/actions/order.ts
@@ -298,7 +298,7 @@ export async function getOrderWithItems(
             },
           },
         },
-        orderBy: { createdAt: 'desc' },
+        orderBy: { createdAt: 'asc' },
       },
     },
     where: { orderUID },


### PR DESCRIPTION
- return the order items in ascending order, so most recent is first in the list