### PR TITLE
feat: DataTable additional children

### DIFF
--- a/src/components/stories/table/DataTable.stories.tsx
+++ b/src/components/stories/table/DataTable.stories.tsx
@@ -1,5 +1,6 @@
 import DataTable from '@/components/table/DataTable';
 import SortableHeader from '@/components/table/SortableHeader';
+import { TableCell, TableRow } from '@/components/ui/table';
 import { faker } from '@faker-js/faker';
 import { Meta, StoryObj } from '@storybook/react';
 import { ColumnDef } from '@tanstack/react-table';
@@ -158,6 +159,35 @@ export const NoResults: Story = {
     return (
       <div>
         <DataTable columns={columns} data={[]} />
+      </div>
+    );
+  },
+};
+
+export const AdditionalChildren: Story = {
+  render: () => {
+    const tableBodyAdditionalChildren = (
+      <>
+        <TableRow>
+          <TableCell colSpan={columns.length}>
+            <div>I&apos;m an additional table row!!</div>
+          </TableCell>
+        </TableRow>
+        <TableRow className="hover:!bg-transparent">
+          <TableCell colSpan={columns.length}>
+            <div>I&apos;m a row that has no hover shading</div>
+          </TableCell>
+        </TableRow>
+      </>
+    );
+
+    return (
+      <div>
+        <DataTable
+          columns={columns}
+          data={data}
+          tableBodyAdditionalChildren={tableBodyAdditionalChildren}
+        />
       </div>
     );
   },

--- a/src/components/table/DataTable.tsx
+++ b/src/components/table/DataTable.tsx
@@ -34,6 +34,7 @@ export type DataTableProps<TData, TValue> = {
   idFieldName?: string;
   isLoading?: boolean;
   linkPathname?: string;
+  tableBodyAdditionalChildren?: React.ReactNode;
   noDataText?: string;
   onNext?: () => Promise<void>;
   onPrevious?: () => Promise<void>;
@@ -46,7 +47,8 @@ export default function DataTable<TData, TValue>({
   idFieldName = 'id',
   isLoading,
   linkPathname,
-  noDataText = 'No items',
+  tableBodyAdditionalChildren,
+  noDataText,
   onNext,
   onPrevious,
   showPagination = !!onNext || !!onPrevious,
@@ -103,11 +105,15 @@ export default function DataTable<TData, TValue>({
           </TableRow>
         ))
       ) : (
-        <TableRow className="hover:!bg-transparent">
-          <TableCell colSpan={columns.length} className="h-24 text-center">
-            {noDataText}
-          </TableCell>
-        </TableRow>
+        <>
+          {noDataText && (
+            <TableRow className="hover:!bg-transparent">
+              <TableCell colSpan={columns.length} className="h-24 text-center">
+                {noDataText}
+              </TableCell>
+            </TableRow>
+          )}
+        </>
       )}
     </>
   );
@@ -134,7 +140,10 @@ export default function DataTable<TData, TValue>({
               </TableRow>
             ))}
           </TableHeader>
-          <TableBody>{tableBody}</TableBody>
+          <TableBody>
+            <>{tableBody}</>
+            {tableBodyAdditionalChildren && <>{tableBodyAdditionalChildren}</>}
+          </TableBody>
         </Table>
       </div>
       {!isLoading && showPagination && (


### PR DESCRIPTION
Update the DataTable component to allow for additional children within the table body, but below the existing contents. This allows us to include additional content from the calling components, further generalizing the DataTable component.

There comes a point when this generalization is too much (which some might argue this is?), but we the design called for a way to insert rows into the table of custom elements. This seemed like the best path forward.

Additionally, no longer default the `noDataText` so we only display it if it is supplied.

Add stories to demo.