### PR TITLE
feat: checkout SKU input redesign

### DIFF
--- a/src/app/checkout/SkuInput.tsx
+++ b/src/app/checkout/SkuInput.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { Input } from '@/components/ui/input';
+import { InputIcon } from '@/components/ui/input-icon';
+import React, { useCallback, useImperativeHandle } from 'react';
+import { SubmitHandler, useForm } from 'react-hook-form';
+
+export type SkuSearchFormInput = {
+  input: string;
+};
+
+export type SkuSearchProps = {
+  isSearching: boolean;
+  onChange: (value: string) => void;
+  onSubmit: SubmitHandler<SkuSearchFormInput>;
+  value: string;
+};
+
+const SkuSearch = React.forwardRef<
+  React.ElementRef<typeof InputIcon>,
+  SkuSearchProps
+>((props, forwardedRef) => {
+  const { isSearching, onChange, onSubmit, value } = props;
+  const { handleSubmit, register } = useForm<SkuSearchFormInput>({
+    values: {
+      input: value,
+    },
+  });
+  const { ref: formRef, ...formRest } = register('input', {
+    onChange(event) {
+      onChange(event.target.value);
+    },
+    required: true,
+  });
+
+  const internalOnSubmit: SubmitHandler<SkuSearchFormInput> = useCallback(
+    (props) => {
+      onSubmit(props);
+    },
+    [onSubmit],
+  );
+
+  // https://stackoverflow.com/a/76739143/3666800
+  const ref = React.useRef<HTMLInputElement | null>(null);
+  useImperativeHandle(forwardedRef, () => ref.current as HTMLInputElement);
+
+  return (
+    <form className="w-full" onSubmit={handleSubmit(internalOnSubmit)}>
+      <div className="flex gap-4 items-end">
+        <div className="flex flex-col flex-1">
+          <Input
+            variant="ghost"
+            className="pl-2 h-[40px]"
+            disabled={isSearching}
+            placeholder="Scan or Enter SKU"
+            // https://www.react-hook-form.com/faqs/#Howtosharerefusage
+            {...formRest}
+            ref={(e) => {
+              formRef(e);
+              ref.current = e;
+            }}
+          />
+        </div>
+      </div>
+    </form>
+  );
+});
+SkuSearch.displayName = 'SkuSearch';
+
+export default SkuSearch;

--- a/src/components/order-item/OrderItemsTable.tsx
+++ b/src/components/order-item/OrderItemsTable.tsx
@@ -77,16 +77,18 @@ const columns: ColumnDef<OrderItemHydrated>[] = [
 export default function OrderItemsTable({
   orderItems,
   isLoading,
+  tableBodyAdditionalChildren,
 }: {
   orderItems: OrderItemHydrated[];
   isLoading?: boolean;
+  tableBodyAdditionalChildren?: React.ReactNode;
 }) {
   return (
     <DataTable
       columns={columns}
       data={orderItems}
       isLoading={isLoading}
-      noDataText="No Order Items found"
+      tableBodyAdditionalChildren={tableBodyAdditionalChildren}
     />
   );
 }

--- a/src/components/stories/order-item/OrderItemsTable.stories.tsx
+++ b/src/components/stories/order-item/OrderItemsTable.stories.tsx
@@ -25,3 +25,9 @@ export const Default: Story = {
     );
   },
 };
+
+export const NoResults: Story = {
+  args: {
+    orderItems: [],
+  },
+};


### PR DESCRIPTION
- remove the animations on the checkout page, as no longer requested by design
- move the SKU input from a component above the table to within the table as the last row
- switch from using the Search component to a local SkuInput component which handles the SKU input for this page.
- remove `noDataText` from OrderItemsTable and provide story to demo