### PR TITLE
feat: adjust invoice discount percentage

### DIFF
--- a/src/lib/money.test.ts
+++ b/src/lib/money.test.ts
@@ -5,6 +5,8 @@ import {
   determineDiscountedAmountInCents,
   computeTax,
   determineDiscountPercentage,
+  discountPercentageToDisplayNumber,
+  discountPercentageDisplayNumberToNumber,
 } from '@/lib/money';
 
 describe('money', () => {
@@ -127,6 +129,38 @@ describe('money', () => {
 
     it('should work with null', () => {
       expect(discountPercentageToDisplayString(null)).toEqual('0%');
+    });
+  });
+
+  describe('discountPercentageToDisplayNumber', () => {
+    it('should work with a simple number', () => {
+      expect(discountPercentageToDisplayNumber(0.56)).toEqual(56);
+    });
+
+    it('should work with a complex number', () => {
+      expect(discountPercentageToDisplayNumber(0.56348)).toEqual(56.35);
+    });
+
+    it('should work with 0', () => {
+      expect(discountPercentageToDisplayNumber(0)).toEqual(0);
+    });
+
+    it('should work with null', () => {
+      expect(discountPercentageToDisplayNumber(null)).toEqual(0);
+    });
+  });
+
+  describe('discountPercentageDisplayNumberToNumber', () => {
+    it('should work with a simple number', () => {
+      expect(discountPercentageDisplayNumberToNumber(56)).toEqual(0.56);
+    });
+
+    it('should work with a complex number', () => {
+      expect(discountPercentageDisplayNumberToNumber(56.35)).toEqual(0.5635);
+    });
+
+    it('should work with 0', () => {
+      expect(discountPercentageDisplayNumberToNumber(0)).toEqual(0);
     });
   });
 

--- a/src/lib/money.test.ts
+++ b/src/lib/money.test.ts
@@ -162,6 +162,10 @@ describe('money', () => {
     it('should work with 0', () => {
       expect(discountPercentageDisplayNumberToNumber(0)).toEqual(0);
     });
+
+    it('should work with undefined', () => {
+      expect(discountPercentageDisplayNumberToNumber(undefined)).toEqual(0);
+    });
   });
 
   describe('computeTax', () => {

--- a/src/lib/money.ts
+++ b/src/lib/money.ts
@@ -36,7 +36,19 @@ export function determineDiscountPercentage({
 export function discountPercentageToDisplayString(
   discountPercentage: number | null,
 ): string {
-  return `${_.round((discountPercentage ?? 0) * 100, 2)}%`;
+  return `${discountPercentageToDisplayNumber(discountPercentage)}%`;
+}
+
+export function discountPercentageToDisplayNumber(
+  discountPercentage: number | null,
+): number {
+  return _.round((discountPercentage ?? 0) * 100, 2);
+}
+
+export function discountPercentageDisplayNumberToNumber(
+  discountPercentageDisplay: number,
+): number {
+  return _.round((discountPercentageDisplay ?? 0) / 100, 4);
 }
 
 export function computeTax(priceInCents: number): number {

--- a/src/lib/money.ts
+++ b/src/lib/money.ts
@@ -46,7 +46,7 @@ export function discountPercentageToDisplayNumber(
 }
 
 export function discountPercentageDisplayNumberToNumber(
-  discountPercentageDisplay: number,
+  discountPercentageDisplay: number | undefined,
 ): number {
   return _.round((discountPercentageDisplay ?? 0) / 100, 4);
 }

--- a/src/lib/transformers/book.test.ts
+++ b/src/lib/transformers/book.test.ts
@@ -54,6 +54,7 @@ describe('book transformers', () => {
   };
   const bookFormInput: BookFormInput = {
     authors: 'Author 1, Author 2',
+    discountPercentageDisplay: undefined,
     formatId: 2,
     genreId: 3,
     imageUrl: 'http://image.com',

--- a/src/lib/transformers/book.ts
+++ b/src/lib/transformers/book.ts
@@ -15,6 +15,7 @@ export function transformBookHydratedToBookFormInput({
 }): BookFormInput {
   return {
     authors: bookHydrated.authors.map((a) => a.name).join(', '),
+    discountPercentageDisplay: undefined,
     formatId: bookHydrated.format.id,
     genreId: bookHydrated.genre.id,
     imageUrl: bookHydrated.imageUrl,

--- a/src/types/BookFormInput.ts
+++ b/src/types/BookFormInput.ts
@@ -9,7 +9,7 @@ type BookFormInput = Omit<
   | 'publishedDate'
   | 'quantity'
 > & {
-  discountPercentageDisplay: number;
+  discountPercentageDisplay: number | undefined;
   formatId: number | undefined;
   genreId: number | undefined;
   isbn13: string;

--- a/src/types/BookFormInput.ts
+++ b/src/types/BookFormInput.ts
@@ -9,6 +9,7 @@ type BookFormInput = Omit<
   | 'publishedDate'
   | 'quantity'
 > & {
+  discountPercentageDisplay: number;
   formatId: number | undefined;
   genreId: number | undefined;
   isbn13: string;

--- a/tests/checkout.spec.ts
+++ b/tests/checkout.spec.ts
@@ -22,12 +22,9 @@ async function addBookToOrder({
   page: Page;
 }) {
   // enter in an ISBN and press enter
-  const skuInput = page.getByLabel('SKU');
+  const skuInput = page.getByPlaceholder('Scan or Enter SKU');
   await skuInput.fill(book.isbn13);
   await skuInput.press('Enter');
-
-  // TODO remove this after the animation is removed from the start of checkout
-  await page.waitForTimeout(1000);
 
   await expect(page.getByText('Pay Now')).toBeVisible();
 

--- a/tests/invoices.spec.ts
+++ b/tests/invoices.spec.ts
@@ -19,7 +19,11 @@ type InvoiceCreateFormInputStrings = Omit<
 
 type BookFormInputStrings = Omit<
   BookFormInput,
-  'formatId' | 'genreId' | 'imageUrl' | 'priceInCents'
+  | 'discountPercentageDisplay'
+  | 'formatId'
+  | 'genreId'
+  | 'imageUrl'
+  | 'priceInCents'
 > & {
   format: string;
   genre: string;


### PR DESCRIPTION
- Update the invoice book form to allow the user to specify the discount percentage. Default the value to the vendor discount percentage.
- Offload the display conversion of the percentage for the UI to the money lib
- Update some e2e tests that were failing