### PR TITLE
feat: editOrderItem API

### DIFF
--- a/src/types/OrderItemUpdateInput.ts
+++ b/src/types/OrderItemUpdateInput.ts
@@ -1,0 +1,7 @@
+import { OrderItem } from '@prisma/client';
+
+type OrderItemUpdateInput = Pick<
+  OrderItem,
+  'productPriceInCents' | 'quantity' | 'totalPriceInCents'
+>;
+export default OrderItemUpdateInput;


### PR DESCRIPTION
- Add a function to edit an order item's details. This will be used to update the discount percentage of an item during checkout.
- Refactor the `recomputeOrderTotals` function to calculate the entire order so it can be reused in both create and edit order items.